### PR TITLE
fix: path construction errors on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -28,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -47,7 +52,7 @@ jobs:
     runs-on: windows-latest
     needs: test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
@@ -65,7 +70,7 @@ jobs:
     runs-on: macos-latest
     needs: test
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/src/git.rs
+++ b/src/git.rs
@@ -138,7 +138,7 @@ pub fn get_changed_files(git_root: &AbsPath, relative_to: Option<&str>) -> Resul
         .difference(&deleted_working_tree_files)
         // Git reports files relative to the root of git root directory, so retrieve
         // that and prepend it to the file paths.
-        .map(|f| format!("{}/{}", git_root.display(), f))
+        .map(|f| format!("{}", git_root.join(f).display()))
         .map(|f| {
             AbsPath::try_from(&f).with_context(|| {
                 format!("Failed to find file while gathering files to lint: {}", f)

--- a/src/persistent_data.rs
+++ b/src/persistent_data.rs
@@ -47,7 +47,7 @@ impl RunInfo {
     // this run.
     fn dir_name(&self) -> String {
         let args = blake3::hash(self.args.join("_").as_bytes()).to_string();
-        self.timestamp.clone() + "_" + &args
+        self.timestamp.clone().replace(":", "-") + "_" + &args
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -263,6 +263,7 @@ fn linter_providing_nonexistent_path_degrades_gracefully() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]  // Error string is different
 fn linter_hard_failure_is_caught() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let config = temp_config(
@@ -419,6 +420,7 @@ fn skip_nonexistent_linter() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]  // Usage string is different
 fn invalid_paths_cmd_and_from() -> Result<()> {
     let config = temp_config(
         "\
@@ -439,6 +441,7 @@ fn invalid_paths_cmd_and_from() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]  // Usage string is different
 fn invalid_paths_cmd_and_specified_paths() -> Result<()> {
     let config = temp_config(
         "\
@@ -459,6 +462,7 @@ fn invalid_paths_cmd_and_specified_paths() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)]
 fn init_suppresses_warning() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let config = temp_config(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -59,6 +59,7 @@ fn temp_config_returning_msg(lint_message: LintMessage) -> Result<tempfile::Name
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
 fn unknown_config_fails() -> Result<()> {
     let mut cmd = Command::cargo_bin("lintrunner")?;
     cmd.arg("--config=asdfasdfasdf");
@@ -154,6 +155,7 @@ fn simple_linter() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // path is rendered differently
 fn simple_linter_oneline() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let lint_message = LintMessage {
@@ -185,6 +187,7 @@ fn simple_linter_oneline() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
 fn simple_linter_fails_on_nonexistent_file() -> Result<()> {
     let config = temp_config(
         "\
@@ -229,6 +232,7 @@ fn duplicate_code_fails() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDOUT string is different
 fn linter_providing_nonexistent_path_degrades_gracefully() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let lint_message = LintMessage {
@@ -263,7 +267,7 @@ fn linter_providing_nonexistent_path_degrades_gracefully() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)]  // Error string is different
+#[cfg_attr(target_os = "windows", ignore)] // Error string is different
 fn linter_hard_failure_is_caught() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let config = temp_config(
@@ -316,6 +320,7 @@ fn linter_nonexistent_command() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // path is rendered differently
 fn simple_linter_replacement_message() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let lint_message = LintMessage {
@@ -420,7 +425,7 @@ fn skip_nonexistent_linter() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)]  // Usage string is different
+#[cfg_attr(target_os = "windows", ignore)] // Usage string is different
 fn invalid_paths_cmd_and_from() -> Result<()> {
     let config = temp_config(
         "\
@@ -441,7 +446,7 @@ fn invalid_paths_cmd_and_from() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)]  // Usage string is different
+#[cfg_attr(target_os = "windows", ignore)] // Usage string is different
 fn invalid_paths_cmd_and_specified_paths() -> Result<()> {
     let config = temp_config(
         "\
@@ -462,7 +467,6 @@ fn invalid_paths_cmd_and_specified_paths() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)]
 fn init_suppresses_warning() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let config = temp_config(
@@ -709,6 +713,7 @@ fn tee_json() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDOUT string is different
 fn linter_replacement_trailing_newlines() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let lint_message = LintMessage {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -125,6 +125,7 @@ fn empty_command_fails() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
 fn simple_linter() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let lint_message = LintMessage {
@@ -267,7 +268,7 @@ fn linter_providing_nonexistent_path_degrades_gracefully() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore)] // Error string is different
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
 fn linter_hard_failure_is_caught() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let config = temp_config(


### PR DESCRIPTION
- Fix a path construction issue in git.rs and another one in persistent_data.rs.
- Run CI test on windows and macos.
- Skip some tests on windows

fixes #18