### PR TITLE
feat: add lint_message.name to oneline output

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -53,8 +53,8 @@ pub fn render_lint_messages_oneline(
 
         writeln!(
             stdout,
-            "{}:{}:{}:{} {} [{}]",
-            display_path, line_number, column, severity, description, lint_message.code
+            "{}:{}:{}:{} {} [{}/{}]",
+            display_path, line_number, column, severity, description, lint_message.code, lint_message.name
         )?;
     }
 

--- a/tests/snapshots/integration_test__simple_linter_oneline.snap
+++ b/tests/snapshots/integration_test__simple_linter_oneline.snap
@@ -4,7 +4,7 @@ expression: output_lines
 
 ---
 - "STDOUT:"
-- "tests/fixtures/fake_source_file.rs:9:1:Advice A dummy linter failure [DUMMY]"
+- "tests/fixtures/fake_source_file.rs:9:1:Advice A dummy linter failure [DUMMY/dummy failure]"
 - ""
 - ""
 - "STDERR:"


### PR DESCRIPTION
One scenario when oneline outputs are useful is when we adopt new linters. We typically need to disable rules inline when introducing linters like mypy. This adds the message `name` so users can copy and paste the violated rules to ignore it.