### PR TITLE
fix: allow --paths-cmd to run on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ blake3 = "1.3.1"
 fern = { version = "0.6.1", features = ["colored"] }
 chrono = "0.4.19"
 dialoguer = "0.10.1"
+shell-words = "1.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/src/git.rs
+++ b/src/git.rs
@@ -18,6 +18,7 @@ pub fn get_head() -> Result<String> {
 pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
     debug!("Running paths_cmd: {}", paths_cmd);
     let argv = shell_words::split(paths_cmd).context("failed to split paths_cmd")?;
+    debug!("Parsed paths_cmd: {:?}", argv);
 
     let output = Command::new(&argv[0])
         .args(&argv[1..])

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,11 +17,19 @@ pub fn get_head() -> Result<String> {
 
 pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
     debug!("Running paths_cmd: {}", paths_cmd);
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(paths_cmd)
-        .output()
-        .context("failed to run provided paths_cmd")?;
+    let output = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .arg("/C")
+            .arg(paths_cmd)
+            .output()
+            .context("failed to run provided paths_cmd on Windows")?
+    } else {
+        Command::new("sh")
+            .arg("-c")
+            .arg(paths_cmd)
+            .output()
+            .context("failed to run provided paths_cmd")?
+    };
 
     let files = std::str::from_utf8(&output.stdout).context("failed to parse paths_cmd output")?;
     let files = files

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,6 +17,9 @@ pub fn get_head() -> Result<String> {
 
 pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
     debug!("Running paths_cmd: {}", paths_cmd);
+    if paths_cmd.is_empty() {
+        return Err(anyhow::Error::msg("paths_cmd is empty"));
+    }
     let argv = shell_words::split(paths_cmd).context("failed to split paths_cmd")?;
     debug!("Parsed paths_cmd: {:?}", argv);
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,19 +17,12 @@ pub fn get_head() -> Result<String> {
 
 pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
     debug!("Running paths_cmd: {}", paths_cmd);
-    let output = if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .arg("/C")
-            .arg(paths_cmd)
-            .output()
-            .context("failed to run provided paths_cmd on Windows")?
-    } else {
-        Command::new("sh")
-            .arg("-c")
-            .arg(paths_cmd)
-            .output()
-            .context("failed to run provided paths_cmd")?
-    };
+    let argv = shell_words::split(paths_cmd).context("failed to split paths_cmd")?;
+
+    let output = Command::new(&argv[0])
+        .args(&argv[1..])
+        .output()
+        .context("failed to run provided paths_cmd")?;
 
     let files = std::str::from_utf8(&output.stdout).context("failed to parse paths_cmd output")?;
     let files = files

--- a/src/git.rs
+++ b/src/git.rs
@@ -18,7 +18,7 @@ pub fn get_head() -> Result<String> {
 pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
     debug!("Running paths_cmd: {}", paths_cmd);
     if paths_cmd.is_empty() {
-        return Err(anyhow::Error::msg("paths_cmd is empty"));
+        return Err(anyhow::Error::msg("paths_cmd is empty. Please provide an executable command."));
     }
     let argv = shell_words::split(paths_cmd).context("failed to split paths_cmd")?;
     debug!("Parsed paths_cmd: {:?}", argv);


### PR DESCRIPTION
This PR changes `get_paths_from_cmd` to run the command directly instead of using shell to run the command.

fixes #22 