### PR TITLE
feat(sarif): update the message format produced by `convert_to_sarif.py`

### DIFF
--- a/tools/convert_to_sarif.py
+++ b/tools/convert_to_sarif.py
@@ -1,12 +1,14 @@
 """Convert the output of lintrunner json to SARIF."""
 
+from __future__ import annotations
+
 import argparse
 import json
 import os
-from typing import Iterable
+from typing import Any, Iterable
 
 
-def format_rule_name(lintrunner_result: dict) -> str:
+def format_rule_name(lintrunner_result: dict[str, Any]) -> str:
     return f"{lintrunner_result['code']}/{lintrunner_result['name']}"
 
 
@@ -16,7 +18,9 @@ def severity_to_github_level(severity: str) -> str:
     return severity
 
 
-def parse_single_lintrunner_result(lintrunner_result: dict) -> tuple:
+def parse_single_lintrunner_result(
+    lintrunner_result: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
     r"""Parse a single lintrunner result.
 
     A result looks like this:
@@ -42,9 +46,7 @@ def parse_single_lintrunner_result(lintrunner_result: dict) -> tuple:
         "ruleId": format_rule_name(lintrunner_result),
         "level": severity_to_github_level(lintrunner_result["severity"]),
         "message": {
-            "text": format_rule_name(lintrunner_result)
-            + "\n"
-            + lintrunner_result["description"],
+            "text": lintrunner_result["description"],
         },
         "locations": [
             {
@@ -66,11 +68,7 @@ def parse_single_lintrunner_result(lintrunner_result: dict) -> tuple:
         "rule": {
             "id": format_rule_name(lintrunner_result),
             "name": format_rule_name(lintrunner_result),
-            "shortDescription": {
-                "text": format_rule_name(lintrunner_result)
-                + ": "
-                + lintrunner_result["description"].split("\n")[0],
-            },
+            "shortDescription": {"text": format_rule_name(lintrunner_result)},
             "fullDescription": {
                 "text": format_rule_name(lintrunner_result)
                 + "\n"
@@ -85,7 +83,7 @@ def parse_single_lintrunner_result(lintrunner_result: dict) -> tuple:
     return result, rule
 
 
-def produce_sarif(lintrunner_results: Iterable[dict]) -> dict:
+def produce_sarif(lintrunner_results: Iterable[dict[str, Any]]) -> dict[str, Any]:
     """Convert the output of lintrunner json to SARIF."""
 
     rules = {}
@@ -114,9 +112,8 @@ def produce_sarif(lintrunner_results: Iterable[dict]) -> dict:
     return sarif
 
 
-def main(args):
+def main(args: Any) -> None:
     """Convert the output of lintrunner json to SARIF."""
-
     with open(args.input, "r", encoding="utf-8") as f:
         lintrunner_jsons = [json.loads(line) for line in f]
 

--- a/tools/convert_to_sarif_test.py
+++ b/tools/convert_to_sarif_test.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import unittest
 
 import convert_to_sarif
 
 
 class TestConvertToSarif(unittest.TestCase):
-    def test_produce_sarif_returns_correct_sarif_result(self):
+    def test_produce_sarif_returns_correct_sarif_result(self) -> None:
         lintrunner_results = [
             {
                 "path": "test.py",
@@ -47,9 +49,7 @@ class TestConvertToSarif(unittest.TestCase):
                                 {
                                     "id": "FLAKE8/test-code",
                                     "name": "FLAKE8/test-code",
-                                    "shortDescription": {
-                                        "text": "FLAKE8/test-code: test description"
-                                    },
+                                    "shortDescription": {"text": "FLAKE8/test-code"},
                                     "fullDescription": {
                                         "text": "FLAKE8/test-code\ntest description"
                                     },
@@ -58,9 +58,7 @@ class TestConvertToSarif(unittest.TestCase):
                                 {
                                     "id": "FLAKE8/test-code-2",
                                     "name": "FLAKE8/test-code-2",
-                                    "shortDescription": {
-                                        "text": "FLAKE8/test-code-2: test description"
-                                    },
+                                    "shortDescription": {"text": "FLAKE8/test-code-2"},
                                     "fullDescription": {
                                         "text": "FLAKE8/test-code-2\ntest description"
                                     },
@@ -73,7 +71,7 @@ class TestConvertToSarif(unittest.TestCase):
                         {
                             "ruleId": "FLAKE8/test-code",
                             "level": "error",
-                            "message": {"text": "FLAKE8/test-code\ntest description"},
+                            "message": {"text": "test description"},
                             "locations": [
                                 {
                                     "physicalLocation": {
@@ -86,7 +84,7 @@ class TestConvertToSarif(unittest.TestCase):
                         {
                             "ruleId": "FLAKE8/test-code-2",
                             "level": "error",
-                            "message": {"text": "FLAKE8/test-code-2\ntest description"},
+                            "message": {"text": "test description"},
                             "locations": [
                                 {
                                     "physicalLocation": {
@@ -99,7 +97,7 @@ class TestConvertToSarif(unittest.TestCase):
                         {
                             "ruleId": "FLAKE8/test-code",
                             "level": "note",
-                            "message": {"text": "FLAKE8/test-code\ntest description"},
+                            "message": {"text": "test description"},
                             "locations": [
                                 {
                                     "physicalLocation": {
@@ -116,7 +114,7 @@ class TestConvertToSarif(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(actual, expected)
 
-    def test_it_handles_relative_paths(self):
+    def test_it_handles_relative_paths(self) -> None:
         lintrunner_results = [
             {
                 "path": "test.py",
@@ -133,7 +131,7 @@ class TestConvertToSarif(unittest.TestCase):
             {
                 "ruleId": "FLAKE8/test-code",
                 "level": "error",
-                "message": {"text": "FLAKE8/test-code\ntest description"},
+                "message": {"text": "test description"},
                 "locations": [
                     {
                         "physicalLocation": {
@@ -146,7 +144,7 @@ class TestConvertToSarif(unittest.TestCase):
         ]
         self.assertEqual(actual["runs"][0]["results"], expected_results)
 
-    def test_it_handles_absolute_paths(self):
+    def test_it_handles_absolute_paths(self) -> None:
         lintrunner_results = [
             {
                 "path": "/path/to/test.py",
@@ -163,7 +161,7 @@ class TestConvertToSarif(unittest.TestCase):
             {
                 "ruleId": "FLAKE8/test-code",
                 "level": "error",
-                "message": {"text": "FLAKE8/test-code\ntest description"},
+                "message": {"text": "test description"},
                 "locations": [
                     {
                         "physicalLocation": {


### PR DESCRIPTION
Simplify the message title to only contain Linter name and Error code. Simply the message body to only contain the lint message body for better visuals.

E.g.

<img width="813" alt="image" src="https://user-images.githubusercontent.com/11205048/212208347-93d862ff-929e-48fc-89d5-b50b52be1bf4.png">

Updated from https://github.com/justinchuby/lintrunner-adapters/blob/main/lintrunner_adapters/tools/convert_to_sarif.py
