### PR TITLE
chore: fix repository url in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ build-backend = "maturin"
 [project]
 name = "lintrunner"
 requires-python = ">=3.6"
-urls = { "Repository" = "https://https://github.com/suo/lintrunner" }
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
+[project.urls]
+repository = "https://github.com/suo/lintrunner"
 
 [tool.maturin]
 bindings = "bin"


### PR DESCRIPTION
There was a typo in the repository url.