### PR TITLE
fix: add a space to the severity on oneline format

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -53,7 +53,7 @@ pub fn render_lint_messages_oneline(
 
         writeln!(
             stdout,
-            "{}:{}:{}:{} {} [{}/{}]",
+            "{}:{}:{} :{} {} [{}/{}]",
             display_path, line_number, column, severity, description, lint_message.code, lint_message.name
         )?;
     }

--- a/tests/snapshots/integration_test__simple_linter_oneline.snap
+++ b/tests/snapshots/integration_test__simple_linter_oneline.snap
@@ -4,7 +4,7 @@ expression: output_lines
 
 ---
 - "STDOUT:"
-- "tests/fixtures/fake_source_file.rs:9:1:Advice A dummy linter failure [DUMMY/dummy failure]"
+- "tests/fixtures/fake_source_file.rs:9:1 :Advice A dummy linter failure [DUMMY/dummy failure]"
 - ""
 - ""
 - "STDERR:"


### PR DESCRIPTION
In VS Code, `command` clicking the path with line numbers will open the file at that line. However with the severity as part of the path, vscode no longer knows how to parse the path. This PR adds a space to allow vscode to recognize the path.


![image](https://user-images.githubusercontent.com/11205048/212604701-7b7cb08b-10ba-4f79-b4ed-7d358b9b1647.png)
