### PR TITLE
fix: replace `+` with `_` in persistent data path

### DIFF
--- a/src/persistent_data.rs
+++ b/src/persistent_data.rs
@@ -47,7 +47,7 @@ impl RunInfo {
     // this run.
     fn dir_name(&self) -> String {
         let args = blake3::hash(self.args.join("_").as_bytes()).to_string();
-        self.timestamp.clone().replace(":", "-") + "_" + &args
+        self.timestamp.clone().replace(":", "-").replace("+", "_") + "_" + &args
     }
 }
 


### PR DESCRIPTION
Because having `+` in the file path would break on Windows.