### PR TITLE
fix: fix and enable rustfmt linter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,0 +1,45 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+jobs:
+  lintrunner:
+    name: lintrunner
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python_version: ["3.11"]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Install Lintrunner
+        run: |
+          pip install .
+          lintrunner init
+      - name: Run lintrunner on all files
+        run: |
+          set +e
+          if ! lintrunner -v --force-color --all-files --tee-json=lint.json; then
+              echo ""
+              echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
+              exit 1
+          fi
+      - name: Store annotations
+        continue-on-error: true
+        run: |
+          # Use jq to massage the JSON lint output into GitHub Actions workflow commands.
+          jq --raw-output \
+            '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))' \
+            lint.json

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -36,10 +36,16 @@ jobs:
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
               exit 1
           fi
-      - name: Store annotations
-        continue-on-error: true
+      - name: Produce SARIF
+        if: always() && matrix.os == 'ubuntu-latest'
         run: |
-          # Use jq to massage the JSON lint output into GitHub Actions workflow commands.
-          jq --raw-output \
-            '"::\(if .severity == "advice" or .severity == "disabled" then "warning" else .severity end) file=\(.path),line=\(.line),col=\(.char),title=\(.code) \(.name)::" + (.description | gsub("\\n"; "%0A"))' \
-            lint.json
+          python tools/convert_to_sarif.py --input lint.json --output lintrunner.sarif
+      - name: Upload SARIF file
+        if: always() && matrix.os == 'ubuntu-latest'
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: lintrunner.sarif
+          category: lintrunner
+          checkout_path: ${{ github.workspace }}

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -28,7 +28,8 @@ jobs:
         run: |
           pip install .
           lintrunner init
-      - name: Run lintrunner on all files
+      - name: Run lintrunner on all files - Linux
+        if: matrix.os != 'windows-latest'
         run: |
           set +e
           if ! lintrunner -v --force-color --all-files --tee-json=lint.json; then
@@ -36,6 +37,9 @@ jobs:
               echo -e "\e[1m\e[36mYou can reproduce these results locally by using \`lintrunner -m main\`.\e[0m"
               exit 1
           fi
+      - name: Run lintrunner on all files - Windows
+        if: matrix.os == 'windows-latest'
+        run: lintrunner -v --force-color --all-files
       - name: Produce SARIF
         if: always() && matrix.os == 'ubuntu-latest'
         run: |

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -8,6 +8,10 @@ on:
       - v*
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
+  cancel-in-progress: true
+
 jobs:
   lintrunner:
     name: lintrunner

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,0 +1,11 @@
+[[linter]]
+code = 'RUSTFMT'
+include_patterns = ['**/*.rs']
+command = [
+    'python',
+    'examples/rustfmt_linter.py',
+    '--binary=rustfmt',
+    '--config-path=rustfmt.toml',
+    '--',
+    '@{{PATHSFILE}}'
+]

--- a/examples/rustfmt_linter.py
+++ b/examples/rustfmt_linter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import concurrent.futures
 import json

--- a/examples/rustfmt_linter.py
+++ b/examples/rustfmt_linter.py
@@ -58,7 +58,6 @@ def strip_path_from_error(error: str) -> str:
 def run_command(
     args: list[str],
     *,
-    timeout: int | None = None,
     stdin: BinaryIO | None = None,
     check: bool = False,
 ) -> subprocess.CompletedProcess[bytes]:
@@ -70,7 +69,6 @@ def run_command(
             capture_output=True,
             shell=False,
             stdin=stdin,
-            timeout=timeout,
             check=check,
         )
     finally:

--- a/examples/rustfmt_linter.py
+++ b/examples/rustfmt_linter.py
@@ -58,38 +58,24 @@ def strip_path_from_error(error: str) -> str:
 def run_command(
     args: list[str],
     *,
-    retries: int = 0,
     timeout: int | None = None,
     stdin: BinaryIO | None = None,
     check: bool = False,
 ) -> subprocess.CompletedProcess[bytes]:
-    remaining_retries = retries
     logging.debug("$ %s", " ".join(args))
     start_time = time.monotonic()
-    while True:
-        try:
-            return subprocess.run(
-                args,
-                capture_output=True,
-                shell=False,
-                stdin=stdin,
-                timeout=timeout,
-                check=check,
-            )
-        except subprocess.TimeoutExpired as err:
-            if remaining_retries == 0:
-                raise err
-            remaining_retries -= 1
-            logging.warning(
-                "(%s/%s) Retrying because command failed with: %r",
-                retries - remaining_retries,
-                retries,
-                err,
-            )
-            time.sleep(1)
-        finally:
-            end_time = time.monotonic()
-            logging.debug("took %dms", (end_time - start_time) * 1000)
+    try:
+        return subprocess.run(
+            args,
+            capture_output=True,
+            shell=False,
+            stdin=stdin,
+            timeout=timeout,
+            check=check,
+        )
+    finally:
+        end_time = time.monotonic()
+        logging.debug("took %dms", (end_time - start_time) * 1000)
 
 
 def check_file(

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,5 +2,5 @@
 # Please keep these in alphabetical order.
 edition = "2018"
 merge_derives = false
-newline_style = "Windows"
+newline_style = "Native"
 use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,4 +2,5 @@
 # Please keep these in alphabetical order.
 edition = "2018"
 merge_derives = false
+newline_style = "Windows"
 use_field_init_shorthand = true


### PR DESCRIPTION
Fix the rustfmt linter because the original command would format not just the specified file but also any files it imported. Now changed to using stdin as input so that only the specified file is formatted.

Created a CI to lint this repo itself.

e.g.

<img width="908" alt="image" src="https://user-images.githubusercontent.com/11205048/216803116-181153ba-f492-4258-9bac-ceee230ae8c8.png">

<img width="661" alt="image" src="https://user-images.githubusercontent.com/11205048/216804134-f55b0b37-40eb-4026-9a01-1d36dfe66ef6.png">
