### PR TITLE
Enable setting default --merge-base-with values

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -1,3 +1,5 @@
+merge_base_with="main"
+
 [[linter]]
 code = 'RUSTFMT'
 include_patterns = ['**/*.rs']

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ file, conventionally named `.lintrunner.toml`.
 Here is an example linter configuration:
 
 ```toml
+merge_base_with = 'main'
+
 [[linter]]
 name = 'FLAKE8'
 include_patterns = [

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -11,8 +11,8 @@ pub struct LintRunnerConfig{
     #[serde(rename = "linter")]
     pub linters: Vec<LintConfig>,
 
-    #[serde(default)]
-    pub merge_base_with: String,
+    #[serde()]
+    pub merge_base_with: Option<String>,
 }
 
 fn is_false(b: &bool) -> bool {

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -7,7 +7,7 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-pub struct LintRunnerConfig{
+pub struct LintRunnerConfig {
     #[serde(rename = "linter")]
     pub linters: Vec<LintConfig>,
 

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -7,9 +7,12 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
-pub struct LintRunnerConfig {
+pub struct LintRunnerConfig{
     #[serde(rename = "linter")]
     pub linters: Vec<LintConfig>,
+
+    #[serde(default)]
+    pub merge_base_with: String,
 }
 
 fn is_false(b: &bool) -> bool {

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -11,6 +11,8 @@ pub struct LintRunnerConfig{
     #[serde(rename = "linter")]
     pub linters: Vec<LintConfig>,
 
+    /// The default value for the `merge_base_with` parameter.
+    /// Recommend setting this is set to your default branch, e.g. `main`
     #[serde()]
     pub merge_base_with: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ fn do_main() -> Result<i32> {
         RevisionOpt::Revision(revision)
     } else if let Some(merge_base_with) = args.merge_base_with {
         RevisionOpt::MergeBaseWith(merge_base_with)
-    } else if !lint_runner_config.merge_base_with.is_some() {
+    } else if lint_runner_config.merge_base_with.is_some() {
         RevisionOpt::MergeBaseWith(lint_runner_config.merge_base_with.clone().expect("Merge base should be defined"))
     } else {
         RevisionOpt::Head

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,8 +212,8 @@ fn do_main() -> Result<i32> {
         RevisionOpt::Revision(revision)
     } else if let Some(merge_base_with) = args.merge_base_with {
         RevisionOpt::MergeBaseWith(merge_base_with)
-    } else if !lint_runner_config.merge_base_with.is_empty() {
-        RevisionOpt::MergeBaseWith(lint_runner_config.merge_base_with.clone())
+    } else if !lint_runner_config.merge_base_with.is_some() {
+        RevisionOpt::MergeBaseWith(lint_runner_config.merge_base_with.clone().expect("Merge base should be defined"))
     } else {
         RevisionOpt::Head
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,8 @@ fn do_main() -> Result<i32> {
         RevisionOpt::Revision(revision)
     } else if let Some(merge_base_with) = args.merge_base_with {
         RevisionOpt::MergeBaseWith(merge_base_with)
+    } else if !lint_runner_config.merge_base_with.is_empty() {
+        RevisionOpt::MergeBaseWith(lint_runner_config.merge_base_with.clone())
     } else {
         RevisionOpt::Head
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,12 @@ fn do_main() -> Result<i32> {
     } else if let Some(merge_base_with) = args.merge_base_with {
         RevisionOpt::MergeBaseWith(merge_base_with)
     } else if lint_runner_config.merge_base_with.is_some() {
-        RevisionOpt::MergeBaseWith(lint_runner_config.merge_base_with.clone().expect("Merge base should be defined"))
+        RevisionOpt::MergeBaseWith(
+            lint_runner_config
+                .merge_base_with
+                .clone()
+                .expect("Merge base should be defined"),
+        )
     } else {
         RevisionOpt::Head
     };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -47,6 +47,7 @@ fn temp_config_returning_msg(lint_message: LintMessage) -> Result<tempfile::Name
     let serialized = serde_json::to_string(&lint_message)?;
     let config = temp_config(&format!(
         "\
+            merge_base = \"some_base\"
             [[linter]]
             code = 'TESTLINTER'
             include_patterns = ['**']


### PR DESCRIPTION
Use the `.lintrunner.toml` file to optionally specify a default value for --merge-base-with

Repos can update their config file, setting this to `main`, `master`, or whatever their default branch name is. Repostories who want the original behavior of lintrunner will keep getting that behavior by default.

Meant to address https://github.com/pytorch/pytorch/issues/93156 

**Testing**
Tested locally by copying over the /target/release/lintrunner to my pytorch repo and validated that:
1) Without any config file changes, lintrunner still behaves as before
2) When I added the `merge_base_with="master"` line to my config, lintrunner started catching linter errors from 2+ commits ago (which were comited after the merge base)