### PR TITLE
implement sapling support in lintrunner

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, convert::TryFrom, process::Command};
 use crate::{
     log_utils::{ensure_output, log_files},
     path::AbsPath,
+    version_control,
 };
 use anyhow::{ensure, Context, Result};
 use log::debug;
@@ -12,8 +13,8 @@ pub struct Repo {
     root: AbsPath,
 }
 
-impl Repo {
-    pub fn new() -> Result<Repo> {
+impl version_control::System for Repo {
+    fn new() -> Result<Repo> {
         // Retrieve the git root based on the current working directory.
         let output = Command::new("git")
             .arg("rev-parse")
@@ -26,14 +27,14 @@ impl Repo {
         })
     }
 
-    pub fn get_head(&self) -> Result<String> {
+    fn get_head(&self) -> Result<String> {
         let output = Command::new("git").arg("rev-parse").arg("HEAD").output()?;
         ensure_output("git rev-parse", &output)?;
         let head = std::str::from_utf8(&output.stdout)?.trim();
         Ok(head.to_string())
     }
 
-    pub fn get_merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+    fn get_merge_base_with(&self, merge_base_with: &str) -> Result<String> {
         let output = Command::new("git")
             .arg("merge-base")
             .arg("HEAD")
@@ -49,7 +50,7 @@ impl Repo {
         Ok(merge_base.to_string())
     }
 
-    pub fn get_changed_files(&self, relative_to: Option<&str>) -> Result<Vec<AbsPath>> {
+    fn get_changed_files(&self, relative_to: Option<&str>) -> Result<Vec<AbsPath>> {
         // Output of --name-status looks like:
         // D    src/lib.rs
         // M    foo/bar.baz

--- a/src/git.rs
+++ b/src/git.rs
@@ -175,106 +175,8 @@ pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, io::Write};
-
     use super::*;
-    use tempfile::TempDir;
-
-    struct GitCheckout {
-        root: TempDir,
-    }
-
-    impl GitCheckout {
-        fn new() -> Result<GitCheckout> {
-            let git = GitCheckout {
-                root: TempDir::new()?,
-            };
-
-            assert_eq!(git.run("init").status()?.code(), Some(0));
-
-            // We add an initial commit because git diff-tree behaves
-            // differently when HEAD is the only commit in the
-            // repository. In actual production uses, our git
-            // diff-tree invocation will show the files modified in
-            // the HEAD commit compared to HEAD~, but if HEAD~ doesn't
-            // exist, it returns an empty list of files.
-            git.write_file("README", "or don't")?;
-            git.add("README")?;
-            git.commit("initial commit")?;
-
-            Ok(git)
-        }
-
-        fn rm_file(&self, name: &str) -> Result<()> {
-            let path = self.root.path().join(name);
-            std::fs::remove_file(path)?;
-            Ok(())
-        }
-
-        fn write_file(&self, name: &str, contents: &str) -> Result<()> {
-            let path = self.root.path().join(name);
-            let mut file = OpenOptions::new()
-                .read(true)
-                .append(true)
-                .create(true)
-                .open(path)?;
-
-            writeln!(file, "{}", contents)?;
-            Ok(())
-        }
-
-        fn checkout_new_branch(&self, branch_name: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["checkout", "-b", branch_name])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn add(&self, pathspec: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["add", pathspec])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn commit(&self, message: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["commit", "-m", message])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
-            std::env::set_current_dir(self.root.path())?;
-            let repo = Repo::new()?;
-            let files = repo.get_changed_files(relative_to)?;
-            let files = files
-                .into_iter()
-                .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
-                .collect::<Vec<_>>();
-            Ok(files)
-        }
-
-        fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
-            std::env::set_current_dir(self.root.path())?;
-            let repo = Repo::new()?;
-            repo.get_merge_base_with(merge_base_with)
-        }
-
-        // Returns a Command to run the subcommand in the clone.
-        fn run(&self, subcommand: &str) -> std::process::Command {
-            let mut cmd = std::process::Command::new("git");
-            cmd.arg(subcommand);
-            cmd.current_dir(self.root.path());
-            cmd
-        }
-    }
+    use crate::testing::GitCheckout;
 
     // Should properly detect changes in the commit (and not check other files)
     #[test]
@@ -344,10 +246,7 @@ mod tests {
         git.add(".")?;
         git.commit("commit 2")?;
 
-        let output = Command::new("git")
-            .args(&["mv", "test_2.txt", "new.txt"])
-            .current_dir(git.root.path())
-            .output()?;
+        let output = git.run("mv").arg("test_2.txt").arg("new.txt").output()?;
         assert!(output.status.success());
 
         let files = git.changed_files(None)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,13 +25,10 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
-use git::get_changed_files;
-use git::get_git_root;
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;
 
-use crate::git::get_merge_base_with;
 use crate::render::render_lint_messages_oneline;
 
 fn group_lints_by_file(
@@ -151,6 +148,7 @@ pub enum RenderOpt {
 }
 
 pub fn do_lint(
+    repo: &git::Repo,
     linters: Vec<Linter>,
     paths_opt: PathsOpt,
     should_apply_patches: bool,
@@ -166,15 +164,14 @@ pub fn do_lint(
 
     let mut files = match paths_opt {
         PathsOpt::Auto => {
-            let git_root = get_git_root()?;
             let relative_to = match revision_opt {
                 RevisionOpt::Head => None,
                 RevisionOpt::Revision(revision) => Some(revision),
                 RevisionOpt::MergeBaseWith(merge_base_with) => {
-                    Some(get_merge_base_with(&git_root, &merge_base_with)?)
+                    Some(repo.get_merge_base_with(&merge_base_with)?)
                 }
             };
-            get_changed_files(&git_root, relative_to.as_deref())?
+            repo.get_changed_files(relative_to.as_deref())?
         }
         PathsOpt::PathsCmd(paths_cmd) => get_paths_from_cmd(&paths_cmd)?,
         PathsOpt::Paths(paths) => get_paths_from_input(paths)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
+#[cfg(test)]
+pub mod testing;
+
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod path;
 pub mod persistent_data;
 pub mod rage;
 pub mod render;
+pub mod sapling;
+pub mod version_control;
 
 #[cfg(test)]
 pub mod testing;
@@ -151,7 +153,7 @@ pub enum RenderOpt {
 }
 
 pub fn do_lint(
-    repo: &git::Repo,
+    repo: &version_control::Repo,
     linters: Vec<Linter>,
     paths_opt: PathsOpt,
     should_apply_patches: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use chrono::SecondsFormat;
 use clap::Parser;
 
 use lintrunner::{
-    do_init, do_lint, git,
+    do_init, do_lint,
     init::check_init_changed,
     lint_config::{get_linters_from_config, LintRunnerConfig},
     log_utils::setup_logger,
@@ -13,7 +13,7 @@ use lintrunner::{
     persistent_data::{ExitInfo, PersistentDataStore, RunInfo},
     rage::do_rage,
     render::print_error,
-    PathsOpt, RenderOpt, RevisionOpt,
+    version_control, PathsOpt, RenderOpt, RevisionOpt,
 };
 use log::debug;
 
@@ -163,7 +163,7 @@ fn do_main() -> Result<i32> {
     debug!("Version: {VERSION}");
     debug!("Passed args: {:?}", std::env::args());
     debug!("Computed args: {:?}", args);
-    let repo = git::Repo::new()?;
+    let repo = version_control::Repo::new()?;
     debug!("Current rev: {}", repo.get_head()?);
 
     let cmd = args.cmd.unwrap_or(SubCommand::Lint);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@ use chrono::SecondsFormat;
 use clap::Parser;
 
 use lintrunner::{
-    do_init, do_lint,
-    git::get_head,
+    do_init, do_lint, git,
     init::check_init_changed,
     lint_config::{get_linters_from_config, LintRunnerConfig},
     log_utils::setup_logger,
@@ -164,7 +163,8 @@ fn do_main() -> Result<i32> {
     debug!("Version: {VERSION}");
     debug!("Passed args: {:?}", std::env::args());
     debug!("Computed args: {:?}", args);
-    debug!("Current rev: {}", get_head()?);
+    let repo = git::Repo::new()?;
+    debug!("Current rev: {}", repo.get_head()?);
 
     let cmd = args.cmd.unwrap_or(SubCommand::Lint);
     let lint_runner_config = LintRunnerConfig::new(&config_path)?;
@@ -245,6 +245,7 @@ fn do_main() -> Result<i32> {
         SubCommand::Format => {
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 true, // always apply patches when we use the format command
@@ -258,6 +259,7 @@ fn do_main() -> Result<i32> {
             // Default command is to just lint.
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 args.apply_patches,

--- a/src/sapling.rs
+++ b/src/sapling.rs
@@ -1,0 +1,417 @@
+use crate::{log_utils, path, version_control};
+
+use anyhow;
+use anyhow::Context;
+
+pub struct Repo {
+    root: path::AbsPath,
+}
+
+impl version_control::System for Repo {
+    fn new() -> anyhow::Result<Self> {
+        let output = std::process::Command::new("sl").arg("root").output()?;
+        anyhow::ensure!(output.status.success(), "Failed to determine Sapling root");
+        let root = std::str::from_utf8(&output.stdout)?.trim();
+        Ok(Repo {
+            root: path::AbsPath::try_from(root)?,
+        })
+    }
+
+    fn get_head(&self) -> anyhow::Result<String> {
+        let mut cmd = std::process::Command::new("sl");
+        cmd.arg("whereami");
+        let output = cmd.current_dir(&self.root).output()?;
+        log_utils::ensure_output(&format!("{:?}", cmd), &output)?;
+        let head = std::str::from_utf8(&output.stdout)?.trim();
+        Ok(head.to_string())
+    }
+
+    fn get_merge_base_with(&self, merge_base_with: &str) -> anyhow::Result<String> {
+        let output = std::process::Command::new("sl")
+            .arg("log")
+            .arg(format!("--rev=ancestor(., {})", merge_base_with))
+            .arg("--template={node}")
+            .current_dir(&self.root)
+            .output()?;
+
+        anyhow::ensure!(
+            output.status.success(),
+            format!("Failed to get most recent common ancestor between . and {merge_base_with}")
+        );
+        let merge_base = std::str::from_utf8(&output.stdout)?.trim();
+        Ok(merge_base.to_string())
+    }
+
+    fn get_changed_files(&self, relative_to: Option<&str>) -> anyhow::Result<Vec<path::AbsPath>> {
+        // Output of sl status looks like:
+        // D    src/lib.rs
+        // M    foo/bar.baz
+        let re = regex::Regex::new(r"^[A-Z?]\s+")?;
+
+        // Retrieve changed files in current commit.
+        let mut cmd = std::process::Command::new("sl");
+        cmd.arg("status");
+        cmd.arg(format!("--rev={}", relative_to.unwrap_or(".^")));
+        cmd.current_dir(&self.root);
+        let output = cmd.output()?;
+        log_utils::ensure_output(&format!("{:?}", cmd), &output)?;
+
+        let commit_files_str = std::str::from_utf8(&output.stdout)?;
+
+        let commit_files: std::collections::HashSet<String> = commit_files_str
+            .split('\n')
+            .map(|x| x.to_string())
+            // Filter out deleted files.
+            .filter(|line| !line.starts_with('R'))
+            .filter(|line| !line.starts_with('!'))
+            // Strip the status prefix.
+            .map(|line| re.replace(&line, "").to_string())
+            .filter(|line| !line.is_empty())
+            .collect();
+
+        log_utils::log_files("Linting commit diff files: ", &commit_files);
+
+        commit_files
+            .into_iter()
+            // Git reports files relative to the root of git root directory, so retrieve
+            // that and prepend it to the file paths.
+            .map(|f| format!("{}", self.root.join(f).display()))
+            .map(|f| {
+                path::AbsPath::try_from(&f).with_context(|| {
+                    format!("Failed to find file while gathering files to lint: {}", f)
+                })
+            })
+            .collect::<anyhow::Result<_>>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::OpenOptions, io::Write};
+
+    use crate::testing;
+
+    use super::*;
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    struct SaplingClone {
+        _temp_dir: TempDir,
+        root: std::path::PathBuf,
+    }
+
+    impl SaplingClone {
+        fn new(git_repo: &testing::GitCheckout) -> Result<SaplingClone> {
+            let temp_dir = TempDir::new()?;
+            assert_eq!(
+                std::process::Command::new("sl")
+                    .arg("clone")
+                    .arg("--git")
+                    .arg(git_repo.root())
+                    .current_dir(temp_dir.path())
+                    .status()?
+                    .code(),
+                Some(0)
+            );
+            let root = temp_dir.path().join(git_repo.root().file_name().unwrap());
+            let sl = SaplingClone {
+                _temp_dir: temp_dir,
+                root,
+            };
+            Ok(sl)
+        }
+
+        fn run(&self, subcommand: &str) -> std::process::Command {
+            let mut cmd = std::process::Command::new("sl");
+            cmd.current_dir(&self.root);
+            cmd.arg(subcommand);
+            cmd
+        }
+
+        fn rm_file(&self, name: &str) -> Result<()> {
+            let path = self.root.join(name);
+            std::fs::remove_file(path)?;
+            Ok(())
+        }
+
+        fn write_file(&self, name: &str, contents: &str) -> Result<()> {
+            let path = self.root.join(name);
+            let mut file = OpenOptions::new()
+                .read(true)
+                .append(true)
+                .create(true)
+                .open(path)?;
+
+            writeln!(file, "{}", contents)?;
+            Ok(())
+        }
+
+        fn add(&self, pathspec: &str) -> Result<()> {
+            assert_eq!(self.run("add").arg(pathspec).status()?.code(), Some(0));
+            Ok(())
+        }
+
+        fn rm(&self, pathspec: &str) -> Result<()> {
+            assert_eq!(self.run("rm").arg(pathspec).status()?.code(), Some(0));
+            Ok(())
+        }
+
+        fn commit(&self, message: &str) -> Result<()> {
+            assert_eq!(
+                self.run("commit")
+                    .arg(format!("--message={}", message))
+                    .status()?
+                    .code(),
+                Some(0)
+            );
+            Ok(())
+        }
+
+        fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
+            std::env::set_current_dir(&self.root)?;
+            use version_control::System;
+            let repo = Repo::new()?;
+            let files = repo.get_changed_files(relative_to)?;
+            let files = files
+                .into_iter()
+                .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
+                .collect::<Vec<_>>();
+            Ok(files)
+        }
+
+        fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+            std::env::set_current_dir(&self.root)?;
+            use version_control::System;
+            let repo = Repo::new()?;
+            repo.get_merge_base_with(merge_base_with)
+        }
+    }
+
+    // Should properly detect changes in the commit (and not check other files)
+    #[test]
+    fn doesnt_detect_unchanged() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        // Don't write anthing to file 2 for this!
+        git.write_file("test_1.txt", "commit 2")?;
+
+        git.add(".")?;
+        git.commit("commit 2")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        // Add some uncomitted changes to the working tree
+        sl.write_file("test_3.txt", "commit 2")?;
+
+        let files = sl.changed_files(None)?;
+        assert_eq!(files.len(), 2);
+        assert!(files.contains(&"test_1.txt".to_string()));
+        assert!(files.contains(&"test_3.txt".to_string()));
+        Ok(())
+    }
+
+    // Files that were deleted in the commit should not be checked, since
+    // obviously they are gone.
+    #[test]
+    fn deleted_files_in_commit() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        sl.rm_file("test_1.txt")?;
+
+        let files = sl.changed_files(None)?; // still looks at the parent commit
+        assert_eq!(files.len(), 2);
+
+        sl.rm("test_1.txt")?;
+
+        sl.commit("removal commit")?;
+
+        // Remove a file in the working tree as well.
+        sl.rm("test_2.txt")?;
+
+        let files = sl.changed_files(None)?;
+        assert_eq!(files.len(), 0);
+        Ok(())
+    }
+
+    // Files that were deleted/moved in the working tree should not be checked,
+    // since obviously they are gone.
+    #[test]
+    fn moved_files_working_tree() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        git.write_file("test_2.txt", "foo")?;
+        git.add(".")?;
+        git.commit("commit 2")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        assert_eq!(
+            sl.run("move")
+                .arg("test_2.txt")
+                .arg("new.txt")
+                .status()?
+                .code(),
+            Some(0)
+        );
+
+        let files = sl.changed_files(None)?;
+        assert!(files.contains(&"new.txt".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn relative_revision() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("I am HEAD~2")?;
+
+        git.write_file("test_1.txt", "foo")?;
+
+        git.add(".")?;
+        git.commit("I am HEAD~1")?;
+
+        git.write_file("test_2.txt", "foo")?;
+
+        git.add(".")?;
+        git.commit("I am HEAD")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        // Add some uncomitted changes to the working tree
+        sl.write_file("test_3.txt", "commit 2")?;
+
+        {
+            // Relative to the HEAD commit, only the working tree changes should
+            // be checked.
+            let files = sl.changed_files(Some("."))?;
+            assert_eq!(files.len(), 1);
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        {
+            let files = sl.changed_files(Some(".^"))?;
+            assert_eq!(files.len(), 2);
+            assert!(files.contains(&"test_2.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        {
+            let files = sl.changed_files(Some(".^^"))?;
+            assert_eq!(files.len(), 3);
+            assert!(files.contains(&"test_1.txt".to_string()));
+            assert!(files.contains(&"test_2.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        Ok(())
+    }
+
+    // File deletions should work correctly even if a relative revision is
+    // specified.
+    #[test]
+    fn deleted_files_relative_revision() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        sl.rm_file("test_1.txt")?;
+
+        let files = sl.changed_files(None)?;
+        assert_eq!(files.len(), 2);
+
+        sl.rm("test_1.txt")?;
+        sl.commit("removal commit")?;
+
+        sl.write_file("test_2.txt", "Initial commit")?;
+        sl.add(".")?;
+        sl.commit("another commit")?;
+
+        assert_eq!(sl.run("sl").status()?.code(), Some(0));
+
+        let files = sl.changed_files(Some(".^^"))?;
+        assert_eq!(files.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn merge_base_with() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+        git.write_file("test_4.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("I am main")?;
+
+        git.checkout_new_branch("branch1")?;
+        git.write_file("test_1.txt", "foo")?;
+        git.add(".")?;
+        git.commit("I am on branch1")?;
+
+        git.checkout_new_branch("branch2")?;
+        git.write_file("test_2.txt", "foo")?;
+        git.add(".")?;
+        git.commit("I am branch2")?;
+
+        git.checkout_new_branch("branch3")?;
+        git.write_file("test_3.txt", "blah")?;
+        git.add(".")?;
+        git.commit("I am branch3")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        // Add some uncomitted changes to the working tree
+        sl.write_file("test_4.txt", "blahblah")?;
+
+        assert_eq!(
+            sl.run("pull")
+                .arg("--bookmark=branch1")
+                .arg("--bookmark=branch2")
+                .status()?
+                .code(),
+            Some(0)
+        );
+
+        {
+            let merge_base = Some(sl.merge_base_with("branch2")?);
+            let files = sl.changed_files(merge_base.as_deref())?;
+            assert_eq!(files.len(), 2);
+            assert!(files.contains(&"test_4.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        {
+            let merge_base = Some(sl.merge_base_with("branch1")?);
+            let files = sl.changed_files(merge_base.as_deref())?;
+            assert_eq!(files.len(), 3);
+            assert!(files.contains(&"test_4.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+            assert!(files.contains(&"test_2.txt".to_string()));
+        }
+        Ok(())
+    }
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,102 @@
+use std::{fs::OpenOptions, io::Write, process::Command};
+
+use crate::git;
+
+use anyhow::Result;
+use tempfile::TempDir;
+
+pub struct GitCheckout {
+    root: TempDir,
+}
+
+impl GitCheckout {
+    pub fn new() -> Result<GitCheckout> {
+        let git = GitCheckout {
+            root: TempDir::new()?,
+        };
+
+        assert_eq!(git.run("init").status()?.code(), Some(0));
+
+        // We add an initial commit because git diff-tree behaves
+        // differently when HEAD is the only commit in the
+        // repository. In actual production uses, our git
+        // diff-tree invocation will show the files modified in
+        // the HEAD commit compared to HEAD~, but if HEAD~ doesn't
+        // exist, it returns an empty list of files.
+        git.write_file("README", "or don't")?;
+        git.add("README")?;
+        git.commit("initial commit")?;
+
+        Ok(git)
+    }
+
+    pub fn rm_file(&self, name: &str) -> Result<()> {
+        let path = self.root.path().join(name);
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    pub fn write_file(&self, name: &str, contents: &str) -> Result<()> {
+        let path = self.root.path().join(name);
+        let mut file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(path)?;
+
+        writeln!(file, "{}", contents)?;
+        Ok(())
+    }
+
+    pub fn checkout_new_branch(&self, branch_name: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["checkout", "-b", branch_name])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn add(&self, pathspec: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["add", pathspec])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn commit(&self, message: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["commit", "-m", message])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
+        std::env::set_current_dir(self.root.path())?;
+        let repo = git::Repo::new()?;
+        let files = repo.get_changed_files(relative_to)?;
+        let files = files
+            .into_iter()
+            .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        Ok(files)
+    }
+
+    pub fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+        std::env::set_current_dir(self.root.path())?;
+        let repo = git::Repo::new()?;
+        repo.get_merge_base_with(merge_base_with)
+    }
+
+    // Returns a Command to run the subcommand in the clone.
+    pub fn run(&self, subcommand: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new("git");
+        cmd.arg(subcommand);
+        cmd.current_dir(self.root.path());
+        cmd
+    }
+}

--- a/src/version_control.rs
+++ b/src/version_control.rs
@@ -1,0 +1,60 @@
+use crate::{git, path, sapling};
+
+use anyhow;
+
+pub struct Repo(RepoImpl);
+
+enum RepoImpl {
+    Git(git::Repo),
+    Sapling(sapling::Repo),
+}
+
+// Trait describing the operations we need in lintrunner for a version
+// control system.
+pub trait System {
+    // Creates a new instance, trying the different implementations we
+    // have available.
+    fn new() -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    // Gets the tip of the repository.
+    fn get_head(&self) -> anyhow::Result<String>;
+
+    // Gets the most recent common ancestor between the tip and the
+    // given commit.
+    fn get_merge_base_with(&self, merge_base_with: &str) -> anyhow::Result<String>;
+
+    // Gets the files that have changed relative to the given commit.
+    fn get_changed_files(&self, relative_to: Option<&str>) -> anyhow::Result<Vec<path::AbsPath>>;
+}
+
+impl Repo {
+    pub fn new() -> anyhow::Result<Self> {
+        git::Repo::new()
+            .and_then(|repo| Ok(Repo(RepoImpl::Git(repo))))
+            .or_else(|_| sapling::Repo::new().and_then(|repo| Ok(Repo(RepoImpl::Sapling(repo)))))
+    }
+
+    pub fn get_head(&self) -> anyhow::Result<String> {
+        self.get_system().get_head()
+    }
+
+    pub fn get_merge_base_with(&self, merge_base_with: &str) -> anyhow::Result<String> {
+        self.get_system().get_merge_base_with(merge_base_with)
+    }
+
+    pub fn get_changed_files(
+        &self,
+        relative_to: Option<&str>,
+    ) -> anyhow::Result<Vec<path::AbsPath>> {
+        self.get_system().get_changed_files(relative_to)
+    }
+
+    fn get_system<'a>(&'a self) -> Box<&'a dyn System> {
+        match &self.0 {
+            RepoImpl::Git(git) => Box::new(git as &dyn System),
+            RepoImpl::Sapling(sapling) => Box::new(sapling as &dyn System),
+        }
+    }
+}


### PR DESCRIPTION
implement sapling support in lintrunner


Summary:
We add a new implementation of the version_control::Repo trait and
hide all the implementations behind an opaque enum.

Test Plan: Verified sapling works in at least the default case.

Reviewers: suo

Subscribers:

Tasks:

Tags:

ghstack-source-id: 0ac1d6fe71df466ddb7a23c233093aa946a58da0
Pull Request resolved: https://github.com/suo/lintrunner/pull/52

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/suo/lintrunner/pull/39).
* __->__ #39
* #45
* #44
* #43
* #42