### PR TITLE
fix git tests that run an unrealistic git diff-tree

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,13 +25,10 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
-use git::get_changed_files;
-use git::get_git_root;
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;
 
-use crate::git::get_merge_base_with;
 use crate::render::render_lint_messages_oneline;
 
 fn group_lints_by_file(
@@ -151,6 +148,7 @@ pub enum RenderOpt {
 }
 
 pub fn do_lint(
+    repo: &git::Repo,
     linters: Vec<Linter>,
     paths_opt: PathsOpt,
     should_apply_patches: bool,
@@ -166,15 +164,14 @@ pub fn do_lint(
 
     let mut files = match paths_opt {
         PathsOpt::Auto => {
-            let git_root = get_git_root()?;
             let relative_to = match revision_opt {
                 RevisionOpt::Head => None,
                 RevisionOpt::Revision(revision) => Some(revision),
                 RevisionOpt::MergeBaseWith(merge_base_with) => {
-                    Some(get_merge_base_with(&git_root, &merge_base_with)?)
+                    Some(repo.get_merge_base_with(&merge_base_with)?)
                 }
             };
-            get_changed_files(&git_root, relative_to.as_deref())?
+            repo.get_changed_files(relative_to.as_deref())?
         }
         PathsOpt::PathsCmd(paths_cmd) => get_paths_from_cmd(&paths_cmd)?,
         PathsOpt::Paths(paths) => get_paths_from_input(paths)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@ use chrono::SecondsFormat;
 use clap::Parser;
 
 use lintrunner::{
-    do_init, do_lint,
-    git::get_head,
+    do_init, do_lint, git,
     init::check_init_changed,
     lint_config::{get_linters_from_config, LintRunnerConfig},
     log_utils::setup_logger,
@@ -164,7 +163,8 @@ fn do_main() -> Result<i32> {
     debug!("Version: {VERSION}");
     debug!("Passed args: {:?}", std::env::args());
     debug!("Computed args: {:?}", args);
-    debug!("Current rev: {}", get_head()?);
+    let repo = git::Repo::new()?;
+    debug!("Current rev: {}", repo.get_head()?);
 
     let cmd = args.cmd.unwrap_or(SubCommand::Lint);
     let lint_runner_config = LintRunnerConfig::new(&config_path)?;
@@ -245,6 +245,7 @@ fn do_main() -> Result<i32> {
         SubCommand::Format => {
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 true, // always apply patches when we use the format command
@@ -258,6 +259,7 @@ fn do_main() -> Result<i32> {
             // Default command is to just lint.
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 args.apply_patches,


### PR DESCRIPTION
fix git tests that run an unrealistic git diff-tree

Summary:
If you run lintrunner at head in an unmodified repo, it will run
against the files in the HEAD commit. This behavior is not seen in the
unit tests that only have a single commit.

Test Plan: Fixed tests, verified locally, and verified with lintrunner.

Reviewers: suo

Subscribers:

Tasks:

Tags:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/suo/lintrunner/pull/40).
* #39
* #41
* __->__ #40
* #38
* #37