### PR TITLE
extract GitCheckout type to a testing module

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -175,106 +175,8 @@ pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, io::Write};
-
     use super::*;
-    use tempfile::TempDir;
-
-    struct GitCheckout {
-        root: TempDir,
-    }
-
-    impl GitCheckout {
-        fn new() -> Result<GitCheckout> {
-            let git = GitCheckout {
-                root: TempDir::new()?,
-            };
-
-            assert_eq!(git.run("init").status()?.code(), Some(0));
-
-            // We add an initial commit because git diff-tree behaves
-            // differently when HEAD is the only commit in the
-            // repository. In actual production uses, our git
-            // diff-tree invocation will show the files modified in
-            // the HEAD commit compared to HEAD~, but if HEAD~ doesn't
-            // exist, it returns an empty list of files.
-            git.write_file("README", "or don't")?;
-            git.add("README")?;
-            git.commit("initial commit")?;
-
-            Ok(git)
-        }
-
-        fn rm_file(&self, name: &str) -> Result<()> {
-            let path = self.root.path().join(name);
-            std::fs::remove_file(path)?;
-            Ok(())
-        }
-
-        fn write_file(&self, name: &str, contents: &str) -> Result<()> {
-            let path = self.root.path().join(name);
-            let mut file = OpenOptions::new()
-                .read(true)
-                .append(true)
-                .create(true)
-                .open(path)?;
-
-            writeln!(file, "{}", contents)?;
-            Ok(())
-        }
-
-        fn checkout_new_branch(&self, branch_name: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["checkout", "-b", branch_name])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn add(&self, pathspec: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["add", pathspec])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn commit(&self, message: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["commit", "-m", message])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
-            std::env::set_current_dir(self.root.path())?;
-            let repo = Repo::new()?;
-            let files = repo.get_changed_files(relative_to)?;
-            let files = files
-                .into_iter()
-                .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
-                .collect::<Vec<_>>();
-            Ok(files)
-        }
-
-        fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
-            std::env::set_current_dir(self.root.path())?;
-            let repo = Repo::new()?;
-            repo.get_merge_base_with(merge_base_with)
-        }
-
-        // Returns a Command to run the subcommand in the clone.
-        fn run(&self, subcommand: &str) -> std::process::Command {
-            let mut cmd = std::process::Command::new("git");
-            cmd.arg(subcommand);
-            cmd.current_dir(self.root.path());
-            cmd
-        }
-    }
+    use crate::testing::GitCheckout;
 
     // Should properly detect changes in the commit (and not check other files)
     #[test]
@@ -344,10 +246,7 @@ mod tests {
         git.add(".")?;
         git.commit("commit 2")?;
 
-        let output = Command::new("git")
-            .args(&["mv", "test_2.txt", "new.txt"])
-            .current_dir(git.root.path())
-            .output()?;
+        let output = git.run("mv").arg("test_2.txt").arg("new.txt").output()?;
         assert!(output.status.success());
 
         let files = git.changed_files(None)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,13 +25,10 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
-use git::get_changed_files;
-use git::get_git_root;
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;
 
-use crate::git::get_merge_base_with;
 use crate::render::render_lint_messages_oneline;
 
 fn group_lints_by_file(
@@ -151,6 +148,7 @@ pub enum RenderOpt {
 }
 
 pub fn do_lint(
+    repo: &git::Repo,
     linters: Vec<Linter>,
     paths_opt: PathsOpt,
     should_apply_patches: bool,
@@ -166,15 +164,14 @@ pub fn do_lint(
 
     let mut files = match paths_opt {
         PathsOpt::Auto => {
-            let git_root = get_git_root()?;
             let relative_to = match revision_opt {
                 RevisionOpt::Head => None,
                 RevisionOpt::Revision(revision) => Some(revision),
                 RevisionOpt::MergeBaseWith(merge_base_with) => {
-                    Some(get_merge_base_with(&git_root, &merge_base_with)?)
+                    Some(repo.get_merge_base_with(&merge_base_with)?)
                 }
             };
-            get_changed_files(&git_root, relative_to.as_deref())?
+            repo.get_changed_files(relative_to.as_deref())?
         }
         PathsOpt::PathsCmd(paths_cmd) => get_paths_from_cmd(&paths_cmd)?,
         PathsOpt::Paths(paths) => get_paths_from_input(paths)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
+#[cfg(test)]
+pub mod testing;
+
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@ use chrono::SecondsFormat;
 use clap::Parser;
 
 use lintrunner::{
-    do_init, do_lint,
-    git::get_head,
+    do_init, do_lint, git,
     init::check_init_changed,
     lint_config::{get_linters_from_config, LintRunnerConfig},
     log_utils::setup_logger,
@@ -164,7 +163,8 @@ fn do_main() -> Result<i32> {
     debug!("Version: {VERSION}");
     debug!("Passed args: {:?}", std::env::args());
     debug!("Computed args: {:?}", args);
-    debug!("Current rev: {}", get_head()?);
+    let repo = git::Repo::new()?;
+    debug!("Current rev: {}", repo.get_head()?);
 
     let cmd = args.cmd.unwrap_or(SubCommand::Lint);
     let lint_runner_config = LintRunnerConfig::new(&config_path)?;
@@ -245,6 +245,7 @@ fn do_main() -> Result<i32> {
         SubCommand::Format => {
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 true, // always apply patches when we use the format command
@@ -258,6 +259,7 @@ fn do_main() -> Result<i32> {
             // Default command is to just lint.
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 args.apply_patches,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,102 @@
+use std::{fs::OpenOptions, io::Write, process::Command};
+
+use crate::git;
+
+use anyhow::Result;
+use tempfile::TempDir;
+
+pub struct GitCheckout {
+    root: TempDir,
+}
+
+impl GitCheckout {
+    pub fn new() -> Result<GitCheckout> {
+        let git = GitCheckout {
+            root: TempDir::new()?,
+        };
+
+        assert_eq!(git.run("init").status()?.code(), Some(0));
+
+        // We add an initial commit because git diff-tree behaves
+        // differently when HEAD is the only commit in the
+        // repository. In actual production uses, our git
+        // diff-tree invocation will show the files modified in
+        // the HEAD commit compared to HEAD~, but if HEAD~ doesn't
+        // exist, it returns an empty list of files.
+        git.write_file("README", "or don't")?;
+        git.add("README")?;
+        git.commit("initial commit")?;
+
+        Ok(git)
+    }
+
+    pub fn rm_file(&self, name: &str) -> Result<()> {
+        let path = self.root.path().join(name);
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    pub fn write_file(&self, name: &str, contents: &str) -> Result<()> {
+        let path = self.root.path().join(name);
+        let mut file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(path)?;
+
+        writeln!(file, "{}", contents)?;
+        Ok(())
+    }
+
+    pub fn checkout_new_branch(&self, branch_name: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["checkout", "-b", branch_name])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn add(&self, pathspec: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["add", pathspec])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn commit(&self, message: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["commit", "-m", message])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
+        std::env::set_current_dir(self.root.path())?;
+        let repo = git::Repo::new()?;
+        let files = repo.get_changed_files(relative_to)?;
+        let files = files
+            .into_iter()
+            .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        Ok(files)
+    }
+
+    pub fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+        std::env::set_current_dir(self.root.path())?;
+        let repo = git::Repo::new()?;
+        repo.get_merge_base_with(merge_base_with)
+    }
+
+    // Returns a Command to run the subcommand in the clone.
+    pub fn run(&self, subcommand: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new("git");
+        cmd.arg(subcommand);
+        cmd.current_dir(self.root.path());
+        cmd
+    }
+}


### PR DESCRIPTION
extract GitCheckout type to a testing module

Summary:
This will be used to set up the sapling tests.

Test Plan: Rely on CI.

Reviewers: suo

Subscribers:

Tasks:

Tags:

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/suo/lintrunner/pull/41).
* #39
* __->__ #41
* #40
* #38
* #37