### PR TITLE
Add command line arguments to specify a set of files to lint through globs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,21 +29,13 @@ jobs:
         run: |
           git config --global user.email "fake@email.com"
           git config --global user.name "mr fake"
-      - name: Install sapling on macos
+      - name: Install and initialize sapling on macos
         if: matrix.os == 'macos-latest'
         run: |
           brew install sapling
-      - name: Install sapling on ubuntu
-        if : matrix.os == 'ubuntu-latest'
-          run: curl -L -o sapling_0.2.20230523-092610+f12b7eee_amd64.Ubuntu22.04.deb https://github.com/facebook/sapling/releases/download/0.2.20230523-092610%2Bf12b7eee/sapling_0.2.20230523-092610%2Bf12b7eee_amd64.Ubuntu22.04.deb
-      - name: Install sapling on Windows
-        if : matrix.os == 'windows-latest'
-          run: |
-          curl -L -o sapling.zip "https://github.com/facebook/sapling/releases/download/0.2.20230523-092610%2Bf12b7eee/sapling_windows_0.2.20230523-092610+f12b7eee_amd64.zip"
-        7z x sapling.zip
-          Expand-Archive sapling.zip 'C:\Program Files'
-          setx PATH "$env:PATH;C:\Program Files\Sapling" -m
-      - run: cargo test
+          sl config --user ui.username "mr fake <fake@email.com>"
+      - name: Run cargo test
+        run: cargo test
         env:
           TMPDIR: ${{ runner.temp }}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,20 @@ jobs:
         run: |
           git config --global user.email "fake@email.com"
           git config --global user.name "mr fake"
+      - name: Install sapling on macos
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install sapling
+      - name: Install sapling on ubuntu
+        if : matrix.os == 'ubuntu-latest'
+          run: curl -L -o sapling_0.2.20230523-092610+f12b7eee_amd64.Ubuntu22.04.deb https://github.com/facebook/sapling/releases/download/0.2.20230523-092610%2Bf12b7eee/sapling_0.2.20230523-092610%2Bf12b7eee_amd64.Ubuntu22.04.deb
+      - name: Install sapling on Windows
+        if : matrix.os == 'windows-latest'
+          run: |
+          curl -L -o sapling.zip "https://github.com/facebook/sapling/releases/download/0.2.20230523-092610%2Bf12b7eee/sapling_windows_0.2.20230523-092610+f12b7eee_amd64.zip"
+        7z x sapling.zip
+          Expand-Archive sapling.zip 'C:\Program Files'
+          setx PATH "$env:PATH;C:\Program Files\Sapling" -m
       - run: cargo test
         env:
           TMPDIR: ${{ runner.temp }}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ you can run:
 lintrunner -m master
 ```
 
+### `--only-lint`
+The --only-lint option accepts a comma-separated list of glob patterns. These patterns specify the set of files that should be subject to linting. The patterns are interpreted relative to the location of the configuration file.
+
+By default, all files (**) are considered for linting.
+
+An example of only linting markdown files in `foo` and `bar` is
+```
+lintrunner --only-lint "foo/*.md, bar/*.md"
+```
+
+### `--exclude-from-linting`
+The --exclude-from-linting option accepts a comma-separated list of glob patterns. Any file matching these patterns will be excluded from the linting process. Again, these patterns are relative to the configuration file's location. If a file matches patterns for both `--only-lint` and `--exclude-from-linting` then the file will not be linted.
+
+For example, if you want to exclude all Markdown (*.md) and Rust (*.rs) files from linting, you would use:
+```
+lintrunner --exclude-from-linting "**/*.md, **/*.rs"
+```
+
 ## Linter configuration
 `lintrunner` knows which linters to run and how by looking at a configuration
 file, conventionally named `.lintrunner.toml`.

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, convert::TryFrom, process::Command};
 use crate::{
     log_utils::{ensure_output, log_files},
     path::AbsPath,
+    version_control,
 };
 use anyhow::{ensure, Context, Result};
 use log::debug;
@@ -12,8 +13,8 @@ pub struct Repo {
     root: AbsPath,
 }
 
-impl Repo {
-    pub fn new() -> Result<Repo> {
+impl version_control::System for Repo {
+    fn new() -> Result<Repo> {
         // Retrieve the git root based on the current working directory.
         let output = Command::new("git")
             .arg("rev-parse")
@@ -26,14 +27,14 @@ impl Repo {
         })
     }
 
-    pub fn get_head(&self) -> Result<String> {
+    fn get_head(&self) -> Result<String> {
         let output = Command::new("git").arg("rev-parse").arg("HEAD").output()?;
         ensure_output("git rev-parse", &output)?;
         let head = std::str::from_utf8(&output.stdout)?.trim();
         Ok(head.to_string())
     }
 
-    pub fn get_merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+    fn get_merge_base_with(&self, merge_base_with: &str) -> Result<String> {
         let output = Command::new("git")
             .arg("merge-base")
             .arg("HEAD")
@@ -49,7 +50,7 @@ impl Repo {
         Ok(merge_base.to_string())
     }
 
-    pub fn get_changed_files(&self, relative_to: Option<&str>) -> Result<Vec<AbsPath>> {
+    fn get_changed_files(&self, relative_to: Option<&str>) -> Result<Vec<AbsPath>> {
         // Output of --name-status looks like:
         // D    src/lib.rs
         // M    foo/bar.baz

--- a/src/git.rs
+++ b/src/git.rs
@@ -175,106 +175,8 @@ pub fn get_paths_from_cmd(paths_cmd: &str) -> Result<Vec<AbsPath>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, io::Write};
-
     use super::*;
-    use tempfile::TempDir;
-
-    struct GitCheckout {
-        root: TempDir,
-    }
-
-    impl GitCheckout {
-        fn new() -> Result<GitCheckout> {
-            let git = GitCheckout {
-                root: TempDir::new()?,
-            };
-
-            assert_eq!(git.run("init").status()?.code(), Some(0));
-
-            // We add an initial commit because git diff-tree behaves
-            // differently when HEAD is the only commit in the
-            // repository. In actual production uses, our git
-            // diff-tree invocation will show the files modified in
-            // the HEAD commit compared to HEAD~, but if HEAD~ doesn't
-            // exist, it returns an empty list of files.
-            git.write_file("README", "or don't")?;
-            git.add("README")?;
-            git.commit("initial commit")?;
-
-            Ok(git)
-        }
-
-        fn rm_file(&self, name: &str) -> Result<()> {
-            let path = self.root.path().join(name);
-            std::fs::remove_file(path)?;
-            Ok(())
-        }
-
-        fn write_file(&self, name: &str, contents: &str) -> Result<()> {
-            let path = self.root.path().join(name);
-            let mut file = OpenOptions::new()
-                .read(true)
-                .append(true)
-                .create(true)
-                .open(path)?;
-
-            writeln!(file, "{}", contents)?;
-            Ok(())
-        }
-
-        fn checkout_new_branch(&self, branch_name: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["checkout", "-b", branch_name])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn add(&self, pathspec: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["add", pathspec])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn commit(&self, message: &str) -> Result<()> {
-            let output = Command::new("git")
-                .args(&["commit", "-m", message])
-                .current_dir(self.root.path())
-                .output()?;
-            assert!(output.status.success());
-            Ok(())
-        }
-
-        fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
-            std::env::set_current_dir(self.root.path())?;
-            let repo = Repo::new()?;
-            let files = repo.get_changed_files(relative_to)?;
-            let files = files
-                .into_iter()
-                .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
-                .collect::<Vec<_>>();
-            Ok(files)
-        }
-
-        fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
-            std::env::set_current_dir(self.root.path())?;
-            let repo = Repo::new()?;
-            repo.get_merge_base_with(merge_base_with)
-        }
-
-        // Returns a Command to run the subcommand in the clone.
-        fn run(&self, subcommand: &str) -> std::process::Command {
-            let mut cmd = std::process::Command::new("git");
-            cmd.arg(subcommand);
-            cmd.current_dir(self.root.path());
-            cmd
-        }
-    }
+    use crate::testing::GitCheckout;
 
     // Should properly detect changes in the commit (and not check other files)
     #[test]
@@ -344,10 +246,7 @@ mod tests {
         git.add(".")?;
         git.commit("commit 2")?;
 
-        let output = Command::new("git")
-            .args(&["mv", "test_2.txt", "new.txt"])
-            .current_dir(git.root.path())
-            .output()?;
+        let output = git.run("mv").arg("test_2.txt").arg("new.txt").output()?;
         assert!(output.status.success());
 
         let files = git.changed_files(None)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,13 +25,10 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
-use git::get_changed_files;
-use git::get_git_root;
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;
 
-use crate::git::get_merge_base_with;
 use crate::render::render_lint_messages_oneline;
 
 fn group_lints_by_file(
@@ -151,6 +148,7 @@ pub enum RenderOpt {
 }
 
 pub fn do_lint(
+    repo: &git::Repo,
     linters: Vec<Linter>,
     paths_opt: PathsOpt,
     should_apply_patches: bool,
@@ -166,15 +164,14 @@ pub fn do_lint(
 
     let mut files = match paths_opt {
         PathsOpt::Auto => {
-            let git_root = get_git_root()?;
             let relative_to = match revision_opt {
                 RevisionOpt::Head => None,
                 RevisionOpt::Revision(revision) => Some(revision),
                 RevisionOpt::MergeBaseWith(merge_base_with) => {
-                    Some(get_merge_base_with(&git_root, &merge_base_with)?)
+                    Some(repo.get_merge_base_with(&merge_base_with)?)
                 }
             };
-            get_changed_files(&git_root, relative_to.as_deref())?
+            repo.get_changed_files(relative_to.as_deref())?
         }
         PathsOpt::PathsCmd(paths_cmd) => get_paths_from_cmd(&paths_cmd)?,
         PathsOpt::Paths(paths) => get_paths_from_input(paths)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ use std::fs::OpenOptions;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use glob::Pattern;
+
 pub mod git;
 pub mod init;
 pub mod lint_config;
@@ -161,6 +163,8 @@ pub fn do_lint(
     enable_spinners: bool,
     revision_opt: RevisionOpt,
     tee_json: Option<String>,
+    included_patterns: Vec<Pattern>,
+    excluded_patterns: Vec<Pattern>,
 ) -> Result<i32> {
     debug!(
         "Running linters: {:?}",
@@ -181,15 +185,35 @@ pub fn do_lint(
         PathsOpt::PathsCmd(paths_cmd) => get_paths_from_cmd(&paths_cmd)?,
         PathsOpt::Paths(paths) => get_paths_from_input(paths)?,
         PathsOpt::PathsFile(file) => get_paths_from_file(file)?,
+
         PathsOpt::AllFiles => get_paths_from_cmd("git grep -Il .")?,
     };
 
     // Sort and unique the files so we pass a consistent ordering to linters
     files.sort();
     files.dedup();
+    if linters.len() > 0 {
+        let config_path = linters[0].config_path.clone();
+        let config_dir = config_path.parent().unwrap();
+        files = files
+            .into_iter()
+            .filter(|path| {
+                included_patterns
+                    .iter()
+                    .any(|pattern| linter::matches_relative_path(&config_dir, &path, pattern))
+            })
+            .collect();
+        files = files
+            .into_iter()
+            .filter(|path| {
+                !excluded_patterns
+                    .iter()
+                    .any(|pattern| linter::matches_relative_path(&config_dir, &path, pattern))
+            })
+            .collect();
+    }
 
     let files = Arc::new(files);
-
     log_utils::log_files("Linting files: ", &files);
 
     let mut thread_handles = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub mod persistent_data;
 pub mod rage;
 pub mod render;
 
+#[cfg(test)]
+pub mod testing;
+
 use git::get_paths_from_cmd;
 use lint_message::LintMessage;
 use render::PrintedLintErrors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod path;
 pub mod persistent_data;
 pub mod rage;
 pub mod render;
+pub mod sapling;
+pub mod version_control;
 
 #[cfg(test)]
 pub mod testing;
@@ -151,7 +153,7 @@ pub enum RenderOpt {
 }
 
 pub fn do_lint(
-    repo: &git::Repo,
+    repo: &version_control::Repo,
     linters: Vec<Linter>,
     paths_opt: PathsOpt,
     should_apply_patches: bool,

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -140,7 +140,6 @@ pub fn get_linters_from_config(
             );
         }
         all_linters.insert(lint_config.code.clone());
-
         let include_patterns = patterns_from_strs(&lint_config.include_patterns)?;
         let exclude_patterns = if let Some(exclude_patterns) = &lint_config.exclude_patterns {
             patterns_from_strs(exclude_patterns)?

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -20,7 +20,7 @@ pub struct Linter {
     pub config_path: AbsPath,
 }
 
-fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
+pub fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
     // Unwrap ok because we already checked that both paths are absolute.
     let relative_path = path_relative_from(from, base).unwrap();
     pattern.matches_with(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use chrono::SecondsFormat;
 use clap::Parser;
 
 use lintrunner::{
-    do_init, do_lint, git,
+    do_init, do_lint,
     init::check_init_changed,
     lint_config::{get_linters_from_config, LintRunnerConfig},
     log_utils::setup_logger,
@@ -13,7 +13,7 @@ use lintrunner::{
     persistent_data::{ExitInfo, PersistentDataStore, RunInfo},
     rage::do_rage,
     render::print_error,
-    PathsOpt, RenderOpt, RevisionOpt,
+    version_control, PathsOpt, RenderOpt, RevisionOpt,
 };
 use log::debug;
 
@@ -163,7 +163,7 @@ fn do_main() -> Result<i32> {
     debug!("Version: {VERSION}");
     debug!("Passed args: {:?}", std::env::args());
     debug!("Computed args: {:?}", args);
-    let repo = git::Repo::new()?;
+    let repo = version_control::Repo::new()?;
     debug!("Current rev: {}", repo.get_head()?);
 
     let cmd = args.cmd.unwrap_or(SubCommand::Lint);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,7 @@ use chrono::SecondsFormat;
 use clap::Parser;
 
 use lintrunner::{
-    do_init, do_lint,
-    git::get_head,
+    do_init, do_lint, git,
     init::check_init_changed,
     lint_config::{get_linters_from_config, LintRunnerConfig},
     log_utils::setup_logger,
@@ -164,7 +163,8 @@ fn do_main() -> Result<i32> {
     debug!("Version: {VERSION}");
     debug!("Passed args: {:?}", std::env::args());
     debug!("Computed args: {:?}", args);
-    debug!("Current rev: {}", get_head()?);
+    let repo = git::Repo::new()?;
+    debug!("Current rev: {}", repo.get_head()?);
 
     let cmd = args.cmd.unwrap_or(SubCommand::Lint);
     let lint_runner_config = LintRunnerConfig::new(&config_path)?;
@@ -245,6 +245,7 @@ fn do_main() -> Result<i32> {
         SubCommand::Format => {
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 true, // always apply patches when we use the format command
@@ -258,6 +259,7 @@ fn do_main() -> Result<i32> {
             // Default command is to just lint.
             check_init_changed(&persistent_data_store, &lint_runner_config)?;
             do_lint(
+                &repo,
                 linters,
                 paths_opt,
                 args.apply_patches,

--- a/src/sapling.rs
+++ b/src/sapling.rs
@@ -189,6 +189,8 @@ mod tests {
 
     // Should properly detect changes in the commit (and not check other files)
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn doesnt_detect_unchanged() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -219,6 +221,8 @@ mod tests {
     // Files that were deleted in the commit should not be checked, since
     // obviously they are gone.
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn deleted_files_in_commit() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -250,6 +254,8 @@ mod tests {
     // Files that were deleted/moved in the working tree should not be checked,
     // since obviously they are gone.
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn moved_files_working_tree() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -277,6 +283,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn relative_revision() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -327,6 +335,8 @@ mod tests {
     // File deletions should work correctly even if a relative revision is
     // specified.
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn deleted_files_relative_revision() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -358,6 +368,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn merge_base_with() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;

--- a/src/sapling.rs
+++ b/src/sapling.rs
@@ -1,0 +1,417 @@
+use crate::{log_utils, path, version_control};
+
+use anyhow;
+use anyhow::Context;
+
+pub struct Repo {
+    root: path::AbsPath,
+}
+
+impl version_control::System for Repo {
+    fn new() -> anyhow::Result<Self> {
+        let output = std::process::Command::new("sl").arg("root").output()?;
+        anyhow::ensure!(output.status.success(), "Failed to determine Sapling root");
+        let root = std::str::from_utf8(&output.stdout)?.trim();
+        Ok(Repo {
+            root: path::AbsPath::try_from(root)?,
+        })
+    }
+
+    fn get_head(&self) -> anyhow::Result<String> {
+        let mut cmd = std::process::Command::new("sl");
+        cmd.arg("whereami");
+        let output = cmd.current_dir(&self.root).output()?;
+        log_utils::ensure_output(&format!("{:?}", cmd), &output)?;
+        let head = std::str::from_utf8(&output.stdout)?.trim();
+        Ok(head.to_string())
+    }
+
+    fn get_merge_base_with(&self, merge_base_with: &str) -> anyhow::Result<String> {
+        let output = std::process::Command::new("sl")
+            .arg("log")
+            .arg(format!("--rev=ancestor(., {})", merge_base_with))
+            .arg("--template={node}")
+            .current_dir(&self.root)
+            .output()?;
+
+        anyhow::ensure!(
+            output.status.success(),
+            format!("Failed to get most recent common ancestor between . and {merge_base_with}")
+        );
+        let merge_base = std::str::from_utf8(&output.stdout)?.trim();
+        Ok(merge_base.to_string())
+    }
+
+    fn get_changed_files(&self, relative_to: Option<&str>) -> anyhow::Result<Vec<path::AbsPath>> {
+        // Output of sl status looks like:
+        // D    src/lib.rs
+        // M    foo/bar.baz
+        let re = regex::Regex::new(r"^[A-Z?]\s+")?;
+
+        // Retrieve changed files in current commit.
+        let mut cmd = std::process::Command::new("sl");
+        cmd.arg("status");
+        cmd.arg(format!("--rev={}", relative_to.unwrap_or(".^")));
+        cmd.current_dir(&self.root);
+        let output = cmd.output()?;
+        log_utils::ensure_output(&format!("{:?}", cmd), &output)?;
+
+        let commit_files_str = std::str::from_utf8(&output.stdout)?;
+
+        let commit_files: std::collections::HashSet<String> = commit_files_str
+            .split('\n')
+            .map(|x| x.to_string())
+            // Filter out deleted files.
+            .filter(|line| !line.starts_with('R'))
+            .filter(|line| !line.starts_with('!'))
+            // Strip the status prefix.
+            .map(|line| re.replace(&line, "").to_string())
+            .filter(|line| !line.is_empty())
+            .collect();
+
+        log_utils::log_files("Linting commit diff files: ", &commit_files);
+
+        commit_files
+            .into_iter()
+            // Git reports files relative to the root of git root directory, so retrieve
+            // that and prepend it to the file paths.
+            .map(|f| format!("{}", self.root.join(f).display()))
+            .map(|f| {
+                path::AbsPath::try_from(&f).with_context(|| {
+                    format!("Failed to find file while gathering files to lint: {}", f)
+                })
+            })
+            .collect::<anyhow::Result<_>>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::OpenOptions, io::Write};
+
+    use crate::testing;
+
+    use super::*;
+    use anyhow::Result;
+    use tempfile::TempDir;
+
+    struct SaplingClone {
+        _temp_dir: TempDir,
+        root: std::path::PathBuf,
+    }
+
+    impl SaplingClone {
+        fn new(git_repo: &testing::GitCheckout) -> Result<SaplingClone> {
+            let temp_dir = TempDir::new()?;
+            assert_eq!(
+                std::process::Command::new("sl")
+                    .arg("clone")
+                    .arg("--git")
+                    .arg(git_repo.root())
+                    .current_dir(temp_dir.path())
+                    .status()?
+                    .code(),
+                Some(0)
+            );
+            let root = temp_dir.path().join(git_repo.root().file_name().unwrap());
+            let sl = SaplingClone {
+                _temp_dir: temp_dir,
+                root,
+            };
+            Ok(sl)
+        }
+
+        fn run(&self, subcommand: &str) -> std::process::Command {
+            let mut cmd = std::process::Command::new("sl");
+            cmd.current_dir(&self.root);
+            cmd.arg(subcommand);
+            cmd
+        }
+
+        fn rm_file(&self, name: &str) -> Result<()> {
+            let path = self.root.join(name);
+            std::fs::remove_file(path)?;
+            Ok(())
+        }
+
+        fn write_file(&self, name: &str, contents: &str) -> Result<()> {
+            let path = self.root.join(name);
+            let mut file = OpenOptions::new()
+                .read(true)
+                .append(true)
+                .create(true)
+                .open(path)?;
+
+            writeln!(file, "{}", contents)?;
+            Ok(())
+        }
+
+        fn add(&self, pathspec: &str) -> Result<()> {
+            assert_eq!(self.run("add").arg(pathspec).status()?.code(), Some(0));
+            Ok(())
+        }
+
+        fn rm(&self, pathspec: &str) -> Result<()> {
+            assert_eq!(self.run("rm").arg(pathspec).status()?.code(), Some(0));
+            Ok(())
+        }
+
+        fn commit(&self, message: &str) -> Result<()> {
+            assert_eq!(
+                self.run("commit")
+                    .arg(format!("--message={}", message))
+                    .status()?
+                    .code(),
+                Some(0)
+            );
+            Ok(())
+        }
+
+        fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
+            std::env::set_current_dir(&self.root)?;
+            use version_control::System;
+            let repo = Repo::new()?;
+            let files = repo.get_changed_files(relative_to)?;
+            let files = files
+                .into_iter()
+                .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
+                .collect::<Vec<_>>();
+            Ok(files)
+        }
+
+        fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+            std::env::set_current_dir(&self.root)?;
+            use version_control::System;
+            let repo = Repo::new()?;
+            repo.get_merge_base_with(merge_base_with)
+        }
+    }
+
+    // Should properly detect changes in the commit (and not check other files)
+    #[test]
+    fn doesnt_detect_unchanged() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        // Don't write anthing to file 2 for this!
+        git.write_file("test_1.txt", "commit 2")?;
+
+        git.add(".")?;
+        git.commit("commit 2")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        // Add some uncomitted changes to the working tree
+        sl.write_file("test_3.txt", "commit 2")?;
+
+        let files = sl.changed_files(None)?;
+        assert_eq!(files.len(), 2);
+        assert!(files.contains(&"test_1.txt".to_string()));
+        assert!(files.contains(&"test_3.txt".to_string()));
+        Ok(())
+    }
+
+    // Files that were deleted in the commit should not be checked, since
+    // obviously they are gone.
+    #[test]
+    fn deleted_files_in_commit() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        sl.rm_file("test_1.txt")?;
+
+        let files = sl.changed_files(None)?; // still looks at the parent commit
+        assert_eq!(files.len(), 2);
+
+        sl.rm("test_1.txt")?;
+
+        sl.commit("removal commit")?;
+
+        // Remove a file in the working tree as well.
+        sl.rm("test_2.txt")?;
+
+        let files = sl.changed_files(None)?;
+        assert_eq!(files.len(), 0);
+        Ok(())
+    }
+
+    // Files that were deleted/moved in the working tree should not be checked,
+    // since obviously they are gone.
+    #[test]
+    fn moved_files_working_tree() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        git.write_file("test_2.txt", "foo")?;
+        git.add(".")?;
+        git.commit("commit 2")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        assert_eq!(
+            sl.run("move")
+                .arg("test_2.txt")
+                .arg("new.txt")
+                .status()?
+                .code(),
+            Some(0)
+        );
+
+        let files = sl.changed_files(None)?;
+        assert!(files.contains(&"new.txt".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn relative_revision() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("I am HEAD~2")?;
+
+        git.write_file("test_1.txt", "foo")?;
+
+        git.add(".")?;
+        git.commit("I am HEAD~1")?;
+
+        git.write_file("test_2.txt", "foo")?;
+
+        git.add(".")?;
+        git.commit("I am HEAD")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        // Add some uncomitted changes to the working tree
+        sl.write_file("test_3.txt", "commit 2")?;
+
+        {
+            // Relative to the HEAD commit, only the working tree changes should
+            // be checked.
+            let files = sl.changed_files(Some("."))?;
+            assert_eq!(files.len(), 1);
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        {
+            let files = sl.changed_files(Some(".^"))?;
+            assert_eq!(files.len(), 2);
+            assert!(files.contains(&"test_2.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        {
+            let files = sl.changed_files(Some(".^^"))?;
+            assert_eq!(files.len(), 3);
+            assert!(files.contains(&"test_1.txt".to_string()));
+            assert!(files.contains(&"test_2.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        Ok(())
+    }
+
+    // File deletions should work correctly even if a relative revision is
+    // specified.
+    #[test]
+    fn deleted_files_relative_revision() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("commit 1")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        sl.rm_file("test_1.txt")?;
+
+        let files = sl.changed_files(None)?;
+        assert_eq!(files.len(), 2);
+
+        sl.rm("test_1.txt")?;
+        sl.commit("removal commit")?;
+
+        sl.write_file("test_2.txt", "Initial commit")?;
+        sl.add(".")?;
+        sl.commit("another commit")?;
+
+        assert_eq!(sl.run("sl").status()?.code(), Some(0));
+
+        let files = sl.changed_files(Some(".^^"))?;
+        assert_eq!(files.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn merge_base_with() -> Result<()> {
+        let git = testing::GitCheckout::new()?;
+        git.write_file("test_1.txt", "Initial commit")?;
+        git.write_file("test_2.txt", "Initial commit")?;
+        git.write_file("test_3.txt", "Initial commit")?;
+        git.write_file("test_4.txt", "Initial commit")?;
+
+        git.add(".")?;
+        git.commit("I am main")?;
+
+        git.checkout_new_branch("branch1")?;
+        git.write_file("test_1.txt", "foo")?;
+        git.add(".")?;
+        git.commit("I am on branch1")?;
+
+        git.checkout_new_branch("branch2")?;
+        git.write_file("test_2.txt", "foo")?;
+        git.add(".")?;
+        git.commit("I am branch2")?;
+
+        git.checkout_new_branch("branch3")?;
+        git.write_file("test_3.txt", "blah")?;
+        git.add(".")?;
+        git.commit("I am branch3")?;
+
+        let sl = SaplingClone::new(&git)?;
+
+        // Add some uncomitted changes to the working tree
+        sl.write_file("test_4.txt", "blahblah")?;
+
+        assert_eq!(
+            sl.run("pull")
+                .arg("--bookmark=branch1")
+                .arg("--bookmark=branch2")
+                .status()?
+                .code(),
+            Some(0)
+        );
+
+        {
+            let merge_base = Some(sl.merge_base_with("branch2")?);
+            let files = sl.changed_files(merge_base.as_deref())?;
+            assert_eq!(files.len(), 2);
+            assert!(files.contains(&"test_4.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+        }
+        {
+            let merge_base = Some(sl.merge_base_with("branch1")?);
+            let files = sl.changed_files(merge_base.as_deref())?;
+            assert_eq!(files.len(), 3);
+            assert!(files.contains(&"test_4.txt".to_string()));
+            assert!(files.contains(&"test_3.txt".to_string()));
+            assert!(files.contains(&"test_2.txt".to_string()));
+        }
+        Ok(())
+    }
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,102 @@
+use std::{fs::OpenOptions, io::Write, process::Command};
+
+use crate::git;
+
+use anyhow::Result;
+use tempfile::TempDir;
+
+pub struct GitCheckout {
+    root: TempDir,
+}
+
+impl GitCheckout {
+    pub fn new() -> Result<GitCheckout> {
+        let git = GitCheckout {
+            root: TempDir::new()?,
+        };
+
+        assert_eq!(git.run("init").status()?.code(), Some(0));
+
+        // We add an initial commit because git diff-tree behaves
+        // differently when HEAD is the only commit in the
+        // repository. In actual production uses, our git
+        // diff-tree invocation will show the files modified in
+        // the HEAD commit compared to HEAD~, but if HEAD~ doesn't
+        // exist, it returns an empty list of files.
+        git.write_file("README", "or don't")?;
+        git.add("README")?;
+        git.commit("initial commit")?;
+
+        Ok(git)
+    }
+
+    pub fn rm_file(&self, name: &str) -> Result<()> {
+        let path = self.root.path().join(name);
+        std::fs::remove_file(path)?;
+        Ok(())
+    }
+
+    pub fn write_file(&self, name: &str, contents: &str) -> Result<()> {
+        let path = self.root.path().join(name);
+        let mut file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(path)?;
+
+        writeln!(file, "{}", contents)?;
+        Ok(())
+    }
+
+    pub fn checkout_new_branch(&self, branch_name: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["checkout", "-b", branch_name])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn add(&self, pathspec: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["add", pathspec])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn commit(&self, message: &str) -> Result<()> {
+        let output = Command::new("git")
+            .args(&["commit", "-m", message])
+            .current_dir(self.root.path())
+            .output()?;
+        assert!(output.status.success());
+        Ok(())
+    }
+
+    pub fn changed_files(&self, relative_to: Option<&str>) -> Result<Vec<String>> {
+        std::env::set_current_dir(self.root.path())?;
+        let repo = git::Repo::new()?;
+        let files = repo.get_changed_files(relative_to)?;
+        let files = files
+            .into_iter()
+            .map(|abs_path| abs_path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        Ok(files)
+    }
+
+    pub fn merge_base_with(&self, merge_base_with: &str) -> Result<String> {
+        std::env::set_current_dir(self.root.path())?;
+        let repo = git::Repo::new()?;
+        repo.get_merge_base_with(merge_base_with)
+    }
+
+    // Returns a Command to run the subcommand in the clone.
+    pub fn run(&self, subcommand: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new("git");
+        cmd.arg(subcommand);
+        cmd.current_dir(self.root.path());
+        cmd
+    }
+}

--- a/src/version_control.rs
+++ b/src/version_control.rs
@@ -1,0 +1,60 @@
+use crate::{git, path, sapling};
+
+use anyhow;
+
+pub struct Repo(RepoImpl);
+
+enum RepoImpl {
+    Git(git::Repo),
+    Sapling(sapling::Repo),
+}
+
+// Trait describing the operations we need in lintrunner for a version
+// control system.
+pub trait System {
+    // Creates a new instance, trying the different implementations we
+    // have available.
+    fn new() -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    // Gets the tip of the repository.
+    fn get_head(&self) -> anyhow::Result<String>;
+
+    // Gets the most recent common ancestor between the tip and the
+    // given commit.
+    fn get_merge_base_with(&self, merge_base_with: &str) -> anyhow::Result<String>;
+
+    // Gets the files that have changed relative to the given commit.
+    fn get_changed_files(&self, relative_to: Option<&str>) -> anyhow::Result<Vec<path::AbsPath>>;
+}
+
+impl Repo {
+    pub fn new() -> anyhow::Result<Self> {
+        git::Repo::new()
+            .and_then(|repo| Ok(Repo(RepoImpl::Git(repo))))
+            .or_else(|_| sapling::Repo::new().and_then(|repo| Ok(Repo(RepoImpl::Sapling(repo)))))
+    }
+
+    pub fn get_head(&self) -> anyhow::Result<String> {
+        self.get_system().get_head()
+    }
+
+    pub fn get_merge_base_with(&self, merge_base_with: &str) -> anyhow::Result<String> {
+        self.get_system().get_merge_base_with(merge_base_with)
+    }
+
+    pub fn get_changed_files(
+        &self,
+        relative_to: Option<&str>,
+    ) -> anyhow::Result<Vec<path::AbsPath>> {
+        self.get_system().get_changed_files(relative_to)
+    }
+
+    fn get_system<'a>(&'a self) -> Box<&'a dyn System> {
+        match &self.0 {
+            RepoImpl::Git(git) => Box::new(git as &dyn System),
+            RepoImpl::Sapling(sapling) => Box::new(sapling as &dyn System),
+        }
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -157,6 +157,103 @@ fn simple_linter() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
+fn simple_linter_exclude() -> Result<()> {
+    let data_path = tempfile::tempdir()?;
+    let lint_message = LintMessage {
+        path: Some("tests/fixtures/fake_source_file.rs".to_string()),
+        line: Some(9),
+        char: Some(1),
+        code: "DUMMY".to_string(),
+        name: "dummy failure".to_string(),
+        severity: LintSeverity::Advice,
+        original: None,
+        replacement: None,
+        description: Some("A dummy linter failure".to_string()),
+    };
+    let config = temp_config_returning_msg(lint_message)?;
+
+    let mut cmd = Command::cargo_bin("lintrunner")?;
+    cmd.arg(format!("--config={}", config.path().to_str().unwrap()));
+    cmd.arg(format!(
+        "--data-path={}",
+        data_path.path().to_str().unwrap()
+    ));
+    // Run on a file to ensure that the linter is run.
+    cmd.arg("--exclude-from-linting=**/README.md");
+    cmd.arg("README.md");
+    cmd.assert().success();
+    assert_output_snapshot("simple_linter_exclude", &mut cmd)?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
+fn simple_linter_exclude_multifile() -> Result<()> {
+    let data_path = tempfile::tempdir()?;
+    let lint_message = LintMessage {
+        path: Some("tests/fixtures/fake_source_file.rs".to_string()),
+        line: Some(9),
+        char: Some(1),
+        code: "DUMMY".to_string(),
+        name: "dummy failure".to_string(),
+        severity: LintSeverity::Advice,
+        original: None,
+        replacement: None,
+        description: Some("A dummy linter failure".to_string()),
+    };
+    let config = temp_config_returning_msg(lint_message)?;
+
+    let mut cmd = Command::cargo_bin("lintrunner")?;
+    cmd.arg(format!("--config={}", config.path().to_str().unwrap()));
+    cmd.arg(format!(
+        "--data-path={}",
+        data_path.path().to_str().unwrap()
+    ));
+    // Run on a file to ensure that the linter is run.
+    cmd.arg("--exclude-from-linting=**/README.md");
+    cmd.arg("README.md");
+    cmd.arg("LICENSE");
+    cmd.assert().failure();
+    assert_output_snapshot("simple_linter_exclude_multifile", &mut cmd)?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
+fn simple_linter_only_lint_rs() -> Result<()> {
+    let data_path = tempfile::tempdir()?;
+    let lint_message = LintMessage {
+        path: Some("tests/fixtures/fake_source_file.rs".to_string()),
+        line: Some(9),
+        char: Some(1),
+        code: "DUMMY".to_string(),
+        name: "dummy failure".to_string(),
+        severity: LintSeverity::Advice,
+        original: None,
+        replacement: None,
+        description: Some("A dummy linter failure".to_string()),
+    };
+    let config = temp_config_returning_msg(lint_message)?;
+
+    let mut cmd = Command::cargo_bin("lintrunner")?;
+    cmd.arg(format!("--config={}", config.path().to_str().unwrap()));
+    cmd.arg(format!(
+        "--data-path={}",
+        data_path.path().to_str().unwrap()
+    ));
+    // Run on a file to ensure that the linter is run but it skips everything.
+    cmd.arg("--only-lint=**/*.rs");
+    cmd.arg("README.md");
+    cmd.assert().success();
+    assert_output_snapshot("simple_linter_only_lint_rs", &mut cmd)?;
+
+    Ok(())
+}
+
+#[test]
 #[cfg_attr(target_os = "windows", ignore)] // path is rendered differently
 fn simple_linter_oneline() -> Result<()> {
     let data_path = tempfile::tempdir()?;

--- a/tests/snapshots/integration_test__simple_linter_exclude.snap
+++ b/tests/snapshots/integration_test__simple_linter_exclude.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ok No lint issues.
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+

--- a/tests/snapshots/integration_test__simple_linter_exclude_multifile.snap
+++ b/tests/snapshots/integration_test__simple_linter_exclude_multifile.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ""
+- ""
+- ">>> Lint for tests/fixtures/fake_source_file.rs:"
+- ""
+- "  Advice (DUMMY) dummy failure"
+- "    A dummy linter failure"
+- ""
+- "         6  |use std::io::Write;"
+- "         7  |"
+- "         8  |fn assert_output_snapshot(cmd: &mut Command) -> Result<()> {"
+- "    >>>  9  |    let re = Regex::new(\"<temp-config>\").unwrap();"
+- "        10  |    let output = cmd.output()?;"
+- "        11  |"
+- "        12  |    let output_string = format!("
+- ""
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+

--- a/tests/snapshots/integration_test__simple_linter_only_lint_rs.snap
+++ b/tests/snapshots/integration_test__simple_linter_only_lint_rs.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ok No lint issues.
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+


### PR DESCRIPTION
Add command line arguments to specify a set of files to lint through globs

Adds `-exclude-from-linting=` and `--only-lint` command line arguments to further specify a set of files to lint using globs.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/suo/lintrunner/pull/46).
* __->__ #46
* #47
* #39
* #45
* #44
* #43
* #42