### PR TITLE
add sapling support to ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,21 @@ jobs:
         run: |
           git config --global user.email "fake@email.com"
           git config --global user.name "mr fake"
-      - run: cargo test
+      - name: Install and initialize sapling on macos
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install sapling
+          sl config --user ui.username "mr fake <fake@email.com>"
+      - name: Run cargo test
+        uses: nick-fields/retry@v2.8.2
         env:
           TMPDIR: ${{ runner.temp }}
+        timeout_minutes: 10
+        max_attempts: 10
+        retry_wait_seconds: 90
+        command: |
+          cargo test
+
 
   linux:
     runs-on: ubuntu-latest

--- a/src/sapling.rs
+++ b/src/sapling.rs
@@ -189,6 +189,8 @@ mod tests {
 
     // Should properly detect changes in the commit (and not check other files)
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn doesnt_detect_unchanged() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -219,6 +221,8 @@ mod tests {
     // Files that were deleted in the commit should not be checked, since
     // obviously they are gone.
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn deleted_files_in_commit() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -250,6 +254,8 @@ mod tests {
     // Files that were deleted/moved in the working tree should not be checked,
     // since obviously they are gone.
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn moved_files_working_tree() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -277,6 +283,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn relative_revision() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -327,6 +335,8 @@ mod tests {
     // File deletions should work correctly even if a relative revision is
     // specified.
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn deleted_files_relative_revision() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;
@@ -358,6 +368,8 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)] // remove when sapling installation is better
+    #[cfg_attr(target_os = "linux", ignore)] // remove when sapling installation is better
     fn merge_base_with() -> Result<()> {
         let git = testing::GitCheckout::new()?;
         git.write_file("test_1.txt", "Initial commit")?;


### PR DESCRIPTION
add sapling support to ci


Adds CI testing to sapling changes.

Currently only testing on MacOS as linux / windows binaries seem to be unstable and suseptible to name changes which would break our CI.

Also adding retries to CI as it is flaky

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/suo/lintrunner/pull/53).
* #54
* __->__ #53