### PR TITLE
Add command line arguments to specify a set of files to lint through globs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fern = { version = "0.6.1", features = ["colored"] }
 chrono = "0.4.19"
 dialoguer = "0.10.1"
 shell-words = "1.1.0"
+figment = { version = "0.10", features = ["toml", "env"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ every path in the repo is:
 git grep -Il . | xargs lintrunner
 ```
 
+### `--configs`/ `--config`
+"Comma-separated paths to lintrunner configuration files. 
+Multiple files are merged, with later definitions overriding earlier ones. 
+ONLY THE FIRST is required to be present on your machine. 
+Defaults to `lintrunner.toml, lintrunner.private.toml`. Extra configs like `lintrunner.private.toml`
+ are useful for combining project-wide and local configs."
+
 ### `--paths-cmd`
 Some ways to invoke `xargs` will cause multiple `lintrunner` processes to be
 run, increasing lint time (especially on huge path sets). As an alternative that

--- a/README.md
+++ b/README.md
@@ -82,9 +82,31 @@ you can run:
 lintrunner -m master
 ```
 
+<<<<<<< dest:   9f5c7d743e04 - >: Allow multiple toml files in config
 ### `--all-files`
 This will run lint on all files specified in `.lintrunner.toml`.
 
+||||||| base
+=======
+### `--only-lint`
+The --only-lint option accepts a comma-separated list of glob patterns. These patterns specify the set of files that should be subject to linting. The patterns are interpreted relative to the location of the configuration file.
+
+By default, all files (**) are considered for linting.
+
+An example of only linting markdown files in `foo` and `bar` is
+```
+lintrunner --only-lint "foo/*.md, bar/*.md"
+```
+
+### `--exclude-from-linting`
+The --exclude-from-linting option accepts a comma-separated list of glob patterns. Any file matching these patterns will be excluded from the linting process. Again, these patterns are relative to the configuration file's location. If a file matches patterns for both `--only-lint` and `--exclude-from-linting` then the file will not be linted.
+
+For example, if you want to exclude all Markdown (*.md) and Rust (*.rs) files from linting, you would use:
+```
+lintrunner --exclude-from-linting "**/*.md, **/*.rs"
+```
+
+>>>>>>> source: 36b28011bffa - >: Add command line arguments to specify a set...
 ## Linter configuration
 `lintrunner` knows which linters to run and how by looking at a configuration
 file, conventionally named `.lintrunner.toml`.
@@ -154,6 +176,7 @@ can return a `LintMessage` with `path = None`.
 
 In the event a linter exits non-zero, it will be caught by `lintrunner`and
 presented as a “general linter failure” with stdout/stderr shown to the user.
+<<<<<<< dest:   9f5c7d743e04 - >: Allow multiple toml files in config
 This should be considered a bug in the linter’s implementation of this protocol.
 
 ## Tips for adopting `lintrunner` in a new project
@@ -170,3 +193,7 @@ use `--skip` to skip a long running linter like `MYPY`.
 ## GitHub Action
 
 To use `lintrunner` in a GitHub workflow, you can consider [`lintrunner-action`](https://github.com/justinchuby/lintrunner-action).
+||||||| base
+This should be considered a bug in the linter’s implementation of this protocol.
+=======
+This should be considered a bug in the linter’s implementation of this protocol.>>>>>>> source: 36b28011bffa - >: Add command line arguments to specify a set...

--- a/src/init.rs
+++ b/src/init.rs
@@ -24,7 +24,7 @@ pub fn check_init_changed(
         return Ok(());
     }
     let last_init = last_init.unwrap();
-    let old_config = LintRunnerConfig::new_from_string(&last_init)?;
+    let old_config: LintRunnerConfig = serde_json::from_str(&last_init)?;
 
     let old_init_commands: Vec<_> = old_config.linters.iter().map(|l| &l.init_command).collect();
     let current_init_commands: Vec<_> = current_config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub fn do_init(
     linters: Vec<Linter>,
     dry_run: bool,
     persistent_data_store: &PersistentDataStore,
-    config_path: &AbsPath,
+    config_paths: &Vec<std::string::String>,
 ) -> Result<i32> {
     debug!(
         "Initializing linters: {:?}",
@@ -85,9 +85,7 @@ pub fn do_init(
     for linter in linters {
         linter.init(dry_run)?;
     }
-
-    persistent_data_store.update_last_init(config_path)?;
-
+    persistent_data_store.update_last_init(config_paths)?;
     Ok(0)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ use std::fs::OpenOptions;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use glob::Pattern;
+
 pub mod git;
 pub mod init;
 pub mod lint_config;
@@ -159,6 +161,8 @@ pub fn do_lint(
     enable_spinners: bool,
     revision_opt: RevisionOpt,
     tee_json: Option<String>,
+    included_patterns: Vec<Pattern>,
+    excluded_patterns: Vec<Pattern>,
 ) -> Result<i32> {
     debug!(
         "Running linters: {:?}",
@@ -179,15 +183,35 @@ pub fn do_lint(
         PathsOpt::PathsCmd(paths_cmd) => get_paths_from_cmd(&paths_cmd)?,
         PathsOpt::Paths(paths) => get_paths_from_input(paths)?,
         PathsOpt::PathsFile(file) => get_paths_from_file(file)?,
+
         PathsOpt::AllFiles => get_paths_from_cmd("git grep -Il .")?,
     };
 
     // Sort and unique the files so we pass a consistent ordering to linters
     files.sort();
     files.dedup();
+    if linters.len() > 0 {
+        let config_path = linters[0].primary_config_path.clone();
+        let config_dir = config_path.parent().unwrap();
+        files = files
+            .into_iter()
+            .filter(|path| {
+                included_patterns
+                    .iter()
+                    .any(|pattern| linter::matches_relative_path(&config_dir, &path, pattern))
+            })
+            .collect();
+        files = files
+            .into_iter()
+            .filter(|path| {
+                !excluded_patterns
+                    .iter()
+                    .any(|pattern| linter::matches_relative_path(&config_dir, &path, pattern))
+            })
+            .collect();
+    }
 
     let files = Arc::new(files);
-
     log_utils::log_files("Linting files: ", &files);
 
     let mut thread_handles = Vec::new();

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -19,6 +19,14 @@ pub struct LintRunnerConfig {
     /// Recommend setting this is set to your default branch, e.g. `main`
     #[serde()]
     pub merge_base_with: Option<String>,
+
+    /// The default value for the exclude_from_linting parameter.
+    #[serde()]
+    pub exclude_from_linting: Option<String>,
+
+    /// The default value for the only_lint parameter.
+    #[serde()]
+    pub only_lint: Option<String>,
 }
 
 fn is_false(b: &bool) -> bool {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -17,7 +17,7 @@ pub struct Linter {
     pub exclude_patterns: Vec<Pattern>,
     pub commands: Vec<String>,
     pub init_commands: Option<Vec<String>>,
-    pub config_path: AbsPath,
+    pub primary_config_path: AbsPath,
 }
 
 fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
@@ -39,7 +39,7 @@ fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
 impl Linter {
     fn get_config_dir(&self) -> &Path {
         // Unwrap is fine here because we know this path is absolute and won't be `/`
-        self.config_path.parent().unwrap()
+        self.primary_config_path.parent().unwrap()
     }
 
     fn get_matches(&self, files: &[AbsPath]) -> Vec<AbsPath> {
@@ -180,6 +180,7 @@ impl Linter {
                     .iter()
                     .map(|arg| arg.replace("{{DRYRUN}}", dry_run))
                     .collect();
+                info!("the init commands are {:?}", init_commands);
                 let (program, arguments) = init_commands.split_at(1);
                 debug!(
                     "Running: {} {}",
@@ -194,6 +195,7 @@ impl Linter {
                     .args(arguments)
                     .current_dir(self.get_config_dir())
                     .status()?;
+                info!("the status is {:?}", status);
                 ensure!(
                     status.success(),
                     "lint initializer for '{}' failed with non-zero exit code",

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -20,7 +20,7 @@ pub struct Linter {
     pub primary_config_path: AbsPath,
 }
 
-fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
+pub fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
     // Unwrap ok because we already checked that both paths are absolute.
     let relative_path = path_relative_from(from, base).unwrap();
     pattern.matches_with(

--- a/tests/snapshots/integration_test__invalid_config_fails.snap
+++ b/tests/snapshots/integration_test__invalid_config_fails.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/integration_test.rs
 expression: output_lines
-
 ---
 - "STDOUT:"
 - ""
 - ""
 - "STDERR:"
 - "error:        Config file had invalid schema"
-- "caused_by:             missing field `linter` at line 1 column 1"
+- "caused_by:             missing field `linter`"
 

--- a/tests/snapshots/integration_test__invalid_paths_cmd_and_from.snap
+++ b/tests/snapshots/integration_test__invalid_paths_cmd_and_from.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration_test.rs
 expression: output_lines
-
 ---
 - "STDOUT:"
 - ""
@@ -10,7 +9,7 @@ expression: output_lines
 - "error: The argument '--paths-cmd <PATHS_CMD>' cannot be used with '--paths-from <PATHS_FROM>'"
 - ""
 - "USAGE:"
-- "    lintrunner --config <CONFIG> --paths-cmd <PATHS_CMD>"
+- "    lintrunner --configs <CONFIGS>... --paths-cmd <PATHS_CMD>"
 - ""
 - For more information try --help
 

--- a/tests/snapshots/integration_test__invalid_paths_cmd_and_specified_paths.snap
+++ b/tests/snapshots/integration_test__invalid_paths_cmd_and_specified_paths.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration_test.rs
 expression: output_lines
-
 ---
 - "STDOUT:"
 - ""
@@ -10,7 +9,7 @@ expression: output_lines
 - "error: The argument '--paths-cmd <PATHS_CMD>' cannot be used with '<PATHS>...'"
 - ""
 - "USAGE:"
-- "    lintrunner --config <CONFIG> --paths-cmd <PATHS_CMD>"
+- "    lintrunner --configs <CONFIGS>... --paths-cmd <PATHS_CMD>"
 - ""
 - For more information try --help
 

--- a/tests/snapshots/integration_test__simple_linter_exclude.snap
+++ b/tests/snapshots/integration_test__simple_linter_exclude.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ok No lint issues.
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."

--- a/tests/snapshots/integration_test__simple_linter_exclude_multifile.snap
+++ b/tests/snapshots/integration_test__simple_linter_exclude_multifile.snap
@@ -1,0 +1,24 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ""
+- ""
+- ">>> Lint for tests/fixtures/fake_source_file.rs:"
+- ""
+- "  Advice (DUMMY) dummy failure"
+- "    A dummy linter failure"
+- ""
+- "         6  |use std::io::Write;"
+- "         7  |"
+- "         8  |fn assert_output_snapshot(cmd: &mut Command) -> Result<()> {"
+- "    >>>  9  |    let re = Regex::new(\"<temp-config>\").unwrap();"
+- "        10  |    let output = cmd.output()?;"
+- "        11  |"
+- "        12  |    let output_string = format!("
+- ""
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."

--- a/tests/snapshots/integration_test__simple_linter_fake_second_config.snap
+++ b/tests/snapshots/integration_test__simple_linter_fake_second_config.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ""
+- ""
+- ">>> Lint for tests/fixtures/fake_source_file.rs:"
+- ""
+- "  Advice (DUMMY) dummy failure"
+- "    A dummy linter failure"
+- ""
+- "         6  |use std::io::Write;"
+- "         7  |"
+- "         8  |fn assert_output_snapshot(cmd: &mut Command) -> Result<()> {"
+- "    >>>  9  |    let re = Regex::new(\"<temp-config>\").unwrap();"
+- "        10  |    let output = cmd.output()?;"
+- "        11  |"
+- "        12  |    let output_string = format!("
+- ""
+- ""
+- ""
+- "STDERR:"
+- "Warning: Could not find a lintrunner config at: 'NONEXISTENT_CONFIG'. Continuing without using configuration file."
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+

--- a/tests/snapshots/integration_test__simple_linter_only_lint_rs.snap
+++ b/tests/snapshots/integration_test__simple_linter_only_lint_rs.snap
@@ -1,0 +1,10 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ok No lint issues.
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."

--- a/tests/snapshots/integration_test__simple_linter_two_configs.snap
+++ b/tests/snapshots/integration_test__simple_linter_two_configs.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ""
+- ""
+- ">>> Lint for tests/fixtures/fake_source_file.rs:"
+- ""
+- "  Advice (DUMMY) real dummy failure"
+- "    The real dummy linter failure"
+- ""
+- "         6  |use std::io::Write;"
+- "         7  |"
+- "         8  |fn assert_output_snapshot(cmd: &mut Command) -> Result<()> {"
+- "    >>>  9  |    let re = Regex::new(\"<temp-config>\").unwrap();"
+- "        10  |    let output = cmd.output()?;"
+- "        11  |"
+- "        12  |    let output_string = format!("
+- ""
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+


### PR DESCRIPTION
Add command line arguments to specify a set of files to lint through globs

Add command line arguments to specify a set of files to lint through globs

Adds `-exclude-from-linting=` and `--only-lint` command line arguments to further specify a set of files to lint using globs.

This is mostly useful for the internal usage of lintrunner.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/suo/lintrunner/pull/54).
* __->__ #54
* #56