### PR TITLE
Add command line argument `--only-lint-under-config-dir`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fern = { version = "0.6.1", features = ["colored"] }
 chrono = "0.4.19"
 dialoguer = "0.10.1"
 shell-words = "1.1.0"
+figment = { version = "0.10", features = ["toml", "env"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ every path in the repo is:
 git grep -Il . | xargs lintrunner
 ```
 
+### `--configs`/ `--config`
+"Comma-separated paths to lintrunner configuration files. 
+Multiple files are merged, with later definitions overriding earlier ones. 
+ONLY THE FIRST is required to be present on your machine. 
+Defaults to `lintrunner.toml, lintrunner.private.toml`. Extra configs like `lintrunner.private.toml`
+ are useful for combining project-wide and local configs."
+
 ### `--paths-cmd`
 Some ways to invoke `xargs` will cause multiple `lintrunner` processes to be
 run, increasing lint time (especially on huge path sets). As an alternative that

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ lintrunner -m master
 ### `--all-files`
 This will run lint on all files specified in `.lintrunner.toml`.
 
+### `--only-lint-under-config-dir`
+If set, will only lint files under the directory where the configuration file is located and its subdirectories.
+
 ## Linter configuration
 `lintrunner` knows which linters to run and how by looking at a configuration
 file, conventionally named `.lintrunner.toml`.

--- a/src/init.rs
+++ b/src/init.rs
@@ -24,7 +24,7 @@ pub fn check_init_changed(
         return Ok(());
     }
     let last_init = last_init.unwrap();
-    let old_config = LintRunnerConfig::new_from_string(&last_init)?;
+    let old_config: LintRunnerConfig = serde_json::from_str(&last_init)?;
 
     let old_init_commands: Vec<_> = old_config.linters.iter().map(|l| &l.init_command).collect();
     let current_init_commands: Vec<_> = current_config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub fn do_init(
     linters: Vec<Linter>,
     dry_run: bool,
     persistent_data_store: &PersistentDataStore,
-    config_path: &AbsPath,
+    config_paths: &Vec<std::string::String>,
 ) -> Result<i32> {
     debug!(
         "Initializing linters: {:?}",
@@ -85,9 +85,7 @@ pub fn do_init(
     for linter in linters {
         linter.init(dry_run)?;
     }
-
-    persistent_data_store.update_last_init(config_path)?;
-
+    persistent_data_store.update_last_init(config_paths)?;
     Ok(0)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub fn do_lint(
     enable_spinners: bool,
     revision_opt: RevisionOpt,
     tee_json: Option<String>,
-    only_under_config_dir: bool,
+    only_lint_under_config_dir: bool,
 ) -> Result<i32> {
     debug!(
         "Running linters: {:?}",
@@ -187,7 +187,7 @@ pub fn do_lint(
     files.sort();
     files.dedup();
 
-    if only_under_config_dir{
+    if only_lint_under_config_dir{
         let config_dir = linters[0].get_config_dir();
         files = files
         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,7 @@ pub fn do_lint(
     enable_spinners: bool,
     revision_opt: RevisionOpt,
     tee_json: Option<String>,
+    only_under_config_dir: bool,
 ) -> Result<i32> {
     debug!(
         "Running linters: {:?}",
@@ -185,6 +186,18 @@ pub fn do_lint(
     // Sort and unique the files so we pass a consistent ordering to linters
     files.sort();
     files.dedup();
+
+    if only_under_config_dir{
+        let config_dir = linters[0].get_config_dir();
+        files = files
+        .into_iter()
+        .filter(|path| {
+            path.starts_with(config_dir
+            )
+        })
+        .collect();
+    }
+
 
     let files = Arc::new(files);
 

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -20,6 +20,8 @@ pub struct LintRunnerConfig {
     #[serde()]
     pub merge_base_with: Option<String>,
 
+    /// If set, will only lint files under the directory where the configuration file is located and its subdirectories.
+    /// Supercedes command line argument.
     #[serde()]
     pub only_lint_under_config_dir: Option<bool>,
 }

--- a/src/lint_config.rs
+++ b/src/lint_config.rs
@@ -19,6 +19,9 @@ pub struct LintRunnerConfig {
     /// Recommend setting this is set to your default branch, e.g. `main`
     #[serde()]
     pub merge_base_with: Option<String>,
+
+    #[serde()]
+    pub only_lint_under_config_dir: Option<bool>,
 }
 
 fn is_false(b: &bool) -> bool {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -17,7 +17,7 @@ pub struct Linter {
     pub exclude_patterns: Vec<Pattern>,
     pub commands: Vec<String>,
     pub init_commands: Option<Vec<String>>,
-    pub config_path: AbsPath,
+    pub primary_config_path: AbsPath,
 }
 
 fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
@@ -39,7 +39,7 @@ fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
 impl Linter {
     fn get_config_dir(&self) -> &Path {
         // Unwrap is fine here because we know this path is absolute and won't be `/`
-        self.config_path.parent().unwrap()
+        self.primary_config_path.parent().unwrap()
     }
 
     fn get_matches(&self, files: &[AbsPath]) -> Vec<AbsPath> {
@@ -180,6 +180,7 @@ impl Linter {
                     .iter()
                     .map(|arg| arg.replace("{{DRYRUN}}", dry_run))
                     .collect();
+                info!("the init commands are {:?}", init_commands);
                 let (program, arguments) = init_commands.split_at(1);
                 debug!(
                     "Running: {} {}",
@@ -194,6 +195,7 @@ impl Linter {
                     .args(arguments)
                     .current_dir(self.get_config_dir())
                     .status()?;
+                info!("the status is {:?}", status);
                 ensure!(
                     status.success(),
                     "lint initializer for '{}' failed with non-zero exit code",

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -20,6 +20,7 @@ pub struct Linter {
     pub primary_config_path: AbsPath,
 }
 
+
 fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
     // Unwrap ok because we already checked that both paths are absolute.
     let relative_path = path_relative_from(from, base).unwrap();
@@ -37,7 +38,7 @@ fn matches_relative_path(base: &Path, from: &Path, pattern: &Pattern) -> bool {
 }
 
 impl Linter {
-    fn get_config_dir(&self) -> &Path {
+    pub fn get_config_dir(&self) -> &Path {
         // Unwrap is fine here because we know this path is absolute and won't be `/`
         self.primary_config_path.parent().unwrap()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,10 @@ struct Args {
     /// Run lintrunner on all files in the repo. This could take a while!
     #[clap(long, conflicts_with_all=&["paths", "paths-cmd", "paths-from", "revision", "merge-base-with"], global = true)]
     all_files: bool,
+
+    /// If set, only lint files in the same directory as the primary config file (and subdirectories).
+    #[clap(long, global = true)]
+    only_under_config_dir: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -254,6 +258,13 @@ fn do_main() -> Result<i32> {
         RevisionOpt::Head
     };
 
+    let only_lint_under_config_dir = if lint_runner_config.only_lint_under_config_dir.is_some() {
+        lint_runner_config.only_lint_under_config_dir.unwrap()
+    } else {
+        args.only_under_config_dir
+    };
+    
+
     let paths_opt = if let Some(paths_file) = args.paths_from {
         let path_file = AbsPath::try_from(&paths_file)
             .with_context(|| format!("Failed to find `--paths-from` file '{}'", paths_file))?;
@@ -284,6 +295,7 @@ fn do_main() -> Result<i32> {
                 enable_spinners,
                 revision_opt,
                 args.tee_json,
+                only_lint_under_config_dir,
             )
         }
         SubCommand::Lint => {
@@ -298,6 +310,7 @@ fn do_main() -> Result<i32> {
                 enable_spinners,
                 revision_opt,
                 args.tee_json,
+                only_lint_under_config_dir,
             )
         }
         SubCommand::Rage { invocation } => do_rage(&persistent_data_store, invocation),

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,9 +109,9 @@ struct Args {
     #[clap(long, conflicts_with_all=&["paths", "paths-cmd", "paths-from", "revision", "merge-base-with"], global = true)]
     all_files: bool,
 
-    /// If set, only lint files in the same directory as the primary config file (and subdirectories).
+    /// If set, will only lint files under the directory where the configuration file is located and its subdirectories.
     #[clap(long, global = true)]
-    only_under_config_dir: bool,
+    only_lint_under_config_dir: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -261,7 +261,7 @@ fn do_main() -> Result<i32> {
     let only_lint_under_config_dir = if lint_runner_config.only_lint_under_config_dir.is_some() {
         lint_runner_config.only_lint_under_config_dir.unwrap()
     } else {
-        args.only_under_config_dir
+        args.only_lint_under_config_dir
     };
     
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -179,7 +179,7 @@ fn simple_linter_only_under_dir() -> Result<()> {
         "--data-path={}",
         data_path.path().to_str().unwrap()
     ));
-    cmd.arg("--only-under-config-dir");
+    cmd.arg("--only-lint-under-config-dir");
     // Run on a file to ensure that the linter is run. It should skip the file
     cmd.arg("README.md");
     cmd.assert().success();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -158,6 +158,38 @@ fn simple_linter() -> Result<()> {
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
+fn simple_linter_only_under_dir() -> Result<()> {
+    let data_path = tempfile::tempdir()?;
+    let lint_message = LintMessage {
+        path: Some("tests/fixtures/fake_source_file.rs".to_string()),
+        line: Some(9),
+        char: Some(1),
+        code: "DUMMY".to_string(),
+        name: "dummy failure".to_string(),
+        severity: LintSeverity::Advice,
+        original: None,
+        replacement: None,
+        description: Some("A dummy linter failure".to_string()),
+    };
+    let config = temp_config_returning_msg(lint_message)?;
+
+    let mut cmd = Command::cargo_bin("lintrunner")?;
+    cmd.arg(format!("--config={}", config.path().to_str().unwrap()));
+    cmd.arg(format!(
+        "--data-path={}",
+        data_path.path().to_str().unwrap()
+    ));
+    cmd.arg("--only-under-config-dir");
+    // Run on a file to ensure that the linter is run. It should skip the file
+    cmd.arg("README.md");
+    cmd.assert().success();
+    assert_output_snapshot("simple_linter_only_under_dir", &mut cmd)?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // STDERR string is different
 fn simple_linter_two_configs() -> Result<()> {
     let data_path = tempfile::tempdir()?;
     let lint_message1 = LintMessage {

--- a/tests/snapshots/integration_test__invalid_config_fails.snap
+++ b/tests/snapshots/integration_test__invalid_config_fails.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/integration_test.rs
 expression: output_lines
-
 ---
 - "STDOUT:"
 - ""
 - ""
 - "STDERR:"
 - "error:        Config file had invalid schema"
-- "caused_by:             missing field `linter` at line 1 column 1"
+- "caused_by:             missing field `linter`"
 

--- a/tests/snapshots/integration_test__invalid_paths_cmd_and_from.snap
+++ b/tests/snapshots/integration_test__invalid_paths_cmd_and_from.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration_test.rs
 expression: output_lines
-
 ---
 - "STDOUT:"
 - ""
@@ -10,7 +9,7 @@ expression: output_lines
 - "error: The argument '--paths-cmd <PATHS_CMD>' cannot be used with '--paths-from <PATHS_FROM>'"
 - ""
 - "USAGE:"
-- "    lintrunner --config <CONFIG> --paths-cmd <PATHS_CMD>"
+- "    lintrunner --configs <CONFIGS>... --paths-cmd <PATHS_CMD>"
 - ""
 - For more information try --help
 

--- a/tests/snapshots/integration_test__invalid_paths_cmd_and_specified_paths.snap
+++ b/tests/snapshots/integration_test__invalid_paths_cmd_and_specified_paths.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration_test.rs
 expression: output_lines
-
 ---
 - "STDOUT:"
 - ""
@@ -10,7 +9,7 @@ expression: output_lines
 - "error: The argument '--paths-cmd <PATHS_CMD>' cannot be used with '<PATHS>...'"
 - ""
 - "USAGE:"
-- "    lintrunner --config <CONFIG> --paths-cmd <PATHS_CMD>"
+- "    lintrunner --configs <CONFIGS>... --paths-cmd <PATHS_CMD>"
 - ""
 - For more information try --help
 

--- a/tests/snapshots/integration_test__simple_linter_fake_second_config.snap
+++ b/tests/snapshots/integration_test__simple_linter_fake_second_config.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ""
+- ""
+- ">>> Lint for tests/fixtures/fake_source_file.rs:"
+- ""
+- "  Advice (DUMMY) dummy failure"
+- "    A dummy linter failure"
+- ""
+- "         6  |use std::io::Write;"
+- "         7  |"
+- "         8  |fn assert_output_snapshot(cmd: &mut Command) -> Result<()> {"
+- "    >>>  9  |    let re = Regex::new(\"<temp-config>\").unwrap();"
+- "        10  |    let output = cmd.output()?;"
+- "        11  |"
+- "        12  |    let output_string = format!("
+- ""
+- ""
+- ""
+- "STDERR:"
+- "Warning: Could not find a lintrunner config at: 'NONEXISTENT_CONFIG'. Continuing without using configuration file."
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+

--- a/tests/snapshots/integration_test__simple_linter_only_under_dir.snap
+++ b/tests/snapshots/integration_test__simple_linter_only_under_dir.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ok No lint issues.
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+

--- a/tests/snapshots/integration_test__simple_linter_two_configs.snap
+++ b/tests/snapshots/integration_test__simple_linter_two_configs.snap
@@ -1,0 +1,25 @@
+---
+source: tests/integration_test.rs
+expression: output_lines
+---
+- "STDOUT:"
+- ""
+- ""
+- ">>> Lint for tests/fixtures/fake_source_file.rs:"
+- ""
+- "  Advice (DUMMY) real dummy failure"
+- "    The real dummy linter failure"
+- ""
+- "         6  |use std::io::Write;"
+- "         7  |"
+- "         8  |fn assert_output_snapshot(cmd: &mut Command) -> Result<()> {"
+- "    >>>  9  |    let re = Regex::new(\"<temp-config>\").unwrap();"
+- "        10  |    let output = cmd.output()?;"
+- "        11  |"
+- "        12  |    let output_string = format!("
+- ""
+- ""
+- ""
+- "STDERR:"
+- "WARNING: No previous init data found. If this is the first time you're running lintrunner, you should run `lintrunner init`."
+


### PR DESCRIPTION
Add command line argument `--only-lint-under-config-dir`

Adds command line argument `--only-lint-under-config-dir` option to only lint under the configuration directory. For simplicty this argument can also be added to a configuration file as well.
