### PR TITLE
chore(ci): Add wheels for linux aarch64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        target: [x86_64]
+        target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels


### PR DESCRIPTION
When running inside docker on macos, we need linux aarch64 wheels; build them to make it easier to install on these.