### PR TITLE
feat!: default to config at .config/lintrunner.toml

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,15 +27,16 @@ struct Args {
     #[clap(short, long, parse(from_occurrences), global = true)]
     verbose: u8,
 
-    /// Paths to TOML files specifying linters. Configs are merged, with later files overriding earlier ones.
-    /// Except for the first, all files are optional, with missing ones triggering a warning.
+    /// Paths to TOML files specifying linters, separated by commas.
+    /// Configs are merged, with later files overriding earlier ones.
+    /// Except for the first path, files don't have to exist, but missing ones will trigger a warning.
     /// Relative paths are interpreted with respect to the first config file.
     #[clap(
         long,
         global = true,
         alias = "config",
         multiple = true,
-        default_value = ".lintrunner.toml, .lintrunner.private.toml"
+        default_value = ".lintrunner.toml, .lintrunner.private.toml, .config/lintrunner.toml, .config/lintrunner.private.toml"
     )]
     configs: String,
 


### PR DESCRIPTION
Adds `.config/lintrunner.toml` and `.config/lintrunner.private.toml` to the end of default config paths.

Idea here is that having too much dot files in the repo root is a mess. Alternative is a `.config/`, which alieviates the problem a lot. See https://dot-config.github.io/ and https://github.com/natemoo-re/proload/issues/34.

This is potentially a breaking change, since project that currenty default to `.lintrunner.toml` but also has `.config/lintrunner.toml` will now have root config overridden with the `.config`.

The chance of this happening are very low, so I don't think this will cause any problems.

---

Alternative is to put the new default in the front of the list, but then we would have to change the full default to:
```
.config/lintrunner.toml, .config/lintrunner.private.toml, ../.lintrunner.toml, ../.lintrunner.private.toml
```
... since this the last two paths must be relative to `.config`, which is confusing.