### PR TITLE
Add gist/pastry upload to lintrunner rage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,12 @@ enum SubCommand {
         /// Choose a specific invocation to report on. 0 is the most recent run.
         #[clap(long, short)]
         invocation: Option<usize>,
+        /// Set to upload the report to github gist (if available)
+        #[clap(long, short, action)]
+        gist: bool,
+        /// Set to upload the report to pastry (if available)
+        #[clap(long, short, action)]
+        pastry: bool,
     },
 }
 
@@ -315,7 +321,11 @@ fn do_main() -> Result<i32> {
                 only_lint_under_config_dir,
             )
         }
-        SubCommand::Rage { invocation } => do_rage(&persistent_data_store, invocation),
+        SubCommand::Rage {
+            invocation,
+            gist,
+            pastry,
+        } => do_rage(&persistent_data_store, invocation, gist, pastry),
         SubCommand::List => {
             println!("Available linters:");
             for linter in &lint_runner_config.linters {

--- a/src/rage.rs
+++ b/src/rage.rs
@@ -2,6 +2,9 @@ use crate::persistent_data::{PersistentDataStore, RunInfo};
 use anyhow::{Context, Result};
 use console::style;
 use dialoguer::{theme::ColorfulTheme, Select};
+use std::io::Write;
+use std::process::Command;
+use std::process::Stdio;
 
 fn select_past_runs(persistent_data_store: &PersistentDataStore) -> Result<Option<RunInfo>> {
     let runs = persistent_data_store.past_runs()?;
@@ -34,9 +37,22 @@ fn select_past_runs(persistent_data_store: &PersistentDataStore) -> Result<Optio
     Ok(selection.map(|i| runs.into_iter().nth(i).unwrap().0))
 }
 
+fn upload(report: String, cmd: &mut Command) -> Result<()> {
+    let mut child = cmd.stdin(Stdio::piped()).spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(report.as_bytes())?;
+    }
+
+    child.wait()?;
+    Ok(())
+}
+
 pub fn do_rage(
     persistent_data_store: &PersistentDataStore,
     invocation: Option<usize>,
+    gist: bool,
+    pastry: bool,
 ) -> Result<i32> {
     let run = match invocation {
         Some(invocation) => Some(persistent_data_store.past_run(invocation)?),
@@ -48,7 +64,16 @@ pub fn do_rage(
             let report = persistent_data_store
                 .get_run_report(&run)
                 .context("getting selected run report")?;
-            print!("{}", report);
+            if gist {
+                upload(
+                    report.clone(),
+                    Command::new("gh").args(["gist", "create", "-"]),
+                )?;
+            } else if pastry {
+                upload(report.clone(), &mut Command::new("pastry"))?;
+            } else {
+                print!("{}", report);
+            }
         }
         None => {
             println!("{}", style("Nothing selected, exiting.").yellow());


### PR DESCRIPTION
It is convenient to send the result of `lintrunner rage` a gist. Lets support it natively.

```
(py311) ~/d/lintrunner ❯❯❯ ./target/debug/lintrunner rage --pastry                                                 main ✱
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
✔ Select a past invocation to report · ✕ 2024-04-09T11:03:24.068-07:00: ./target/debug/lintrunner rage --pastry
P1209564520: https://www.internalfb.com/intern/paste/P1209564520/
(py311) ~/d/lintrunner ❯❯❯ ./target/debug/lintrunner rage --gist                                                   main ✱
Warning: Could not find a lintrunner config at: '.lintrunner.private.toml'. Continuing without using configuration file.
✔ Select a past invocation to report · ✓ 2024-04-09T11:09:17.670-07:00: ./target/debug/lintrunner rage --pastry
- Creating gist...
✓ Created secret gist
https://gist.github.com/oulgen/d572796b4e6c7f4c0ba7b373da1b6d0d
```