### PR TITLE
fix(build): build x86_64 wheels for Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        target: [x86_64]
+        target: [x86, x86_64]
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        target: [x86]
+        target: [x86_64]
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels


### PR DESCRIPTION
Previously it was only building x86 wheels.

Fix #72 