### PR TITLE
Handle weird paths in git

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, convert::TryFrom, process::Command};
+use std::{collections::HashSet, convert::TryFrom, ffi::OsStr, path::Path, process::Command};
 
 use crate::{
     log_utils::{ensure_output, log_files},
@@ -160,14 +160,14 @@ impl VersionControl for Repo {
             std::str::from_utf8(&output.stdout).context("failed to parse paths_cmd output")?;
         let files = files
             .lines()
-            .map(|s| s.to_string())
-            .collect::<HashSet<String>>();
-        let mut files = files.into_iter().collect::<Vec<String>>();
+            .map(|s| OsStr::new(s))
+            .collect::<HashSet<&OsStr>>();
+        let mut files = files.into_iter().collect::<Vec<&OsStr>>();
         files.sort();
         files
             .into_iter()
-            .map(AbsPath::try_from)
-            .collect::<Result<_>>()
+            .map(|p: &OsStr| AbsPath::try_from(AsRef::<Path>::as_ref(p)))
+            .collect::<Result<Vec<AbsPath>>>()
     }
 }
 


### PR DESCRIPTION
There are some non utf8? paths in my checkout of pytorch
```
(forpytorch) ls third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb/test/nonlatin
𞤀𞤣𞤤𞤢𞤥 𞤆𞤵𞤤𞤢𞤪.txt                               这是一个示例文本.html
```
which cause lintrunner --all-files to fail for me.

Idk if this is a good idea