### PR TITLE
Pin MacOS CI to x86 runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "fake@email.com"
           git config --global user.name "mr fake"
       - name: Install and initialize sapling on macos
-        if: false && matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
           brew install sapling
           sl config --user ui.username "mr fake <fake@email.com>"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "fake@email.com"
           git config --global user.name "mr fake"
       - name: Install and initialize sapling on macos
-        if: matrix.os == 'macos-latest'
+        if: false && matrix.os == 'macos-latest'
         run: |
           brew install sapling
           sl config --user ui.username "mr fake <fake@email.com>"


### PR DESCRIPTION
As for some weird reason, attempts to use sapling on macos-latest (aka M1 running MacOS Sonoma) will fail with cryptic
```
abort: cannot initialize working copy: When constructing alloc::boxed::Box<dyn commits_trait::DagCommits + core::marker::Send> from dyn storemodel::StoreInfo, "10-git-commits" reported error: resolving a4d6b7469307acae7228d95ee08a4764b1e655f2 to git commit: object not found - no match for id (a4d6b7469307acae7228d95ee08a4764b1e655f2); class=Odb (9); code=NotFound (-3)
```