### PR TITLE
Fix clippy violations

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -344,17 +344,6 @@ impl fmt::Display for Changeset {
     }
 }
 
-struct Line(Option<usize>);
-
-impl fmt::Display for Line {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            None => write!(f, "    "),
-            Some(idx) => write!(f, "{:<4}", idx + 1),
-        }
-    }
-}
-
 pub fn print_error(err: &anyhow::Error) -> std::io::Result<()> {
     let mut stderr = Term::stderr();
     let mut chain = err.chain();


### PR DESCRIPTION
`struct Line` is defined, but not used