### PR TITLE
Fix file handling of --all-files to properly handle non-ascii filenames.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,11 +269,12 @@ fn do_main() -> Result<i32> {
         RevisionOpt::Head
     };
 
-    let only_lint_under_config_dir = if let Some(val) = lint_runner_config.only_lint_under_config_dir {
-        val
-    } else {
-        args.only_lint_under_config_dir
-    };
+    let only_lint_under_config_dir =
+        if let Some(val) = lint_runner_config.only_lint_under_config_dir {
+            val
+        } else {
+            args.only_lint_under_config_dir
+        };
 
     let paths_opt = if let Some(paths_file) = args.paths_from {
         let path_file = AbsPath::try_from(&paths_file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,8 +269,8 @@ fn do_main() -> Result<i32> {
         RevisionOpt::Head
     };
 
-    let only_lint_under_config_dir = if lint_runner_config.only_lint_under_config_dir.is_some() {
-        lint_runner_config.only_lint_under_config_dir.unwrap()
+    let only_lint_under_config_dir = if let Some(val) = lint_runner_config.only_lint_under_config_dir {
+        val
     } else {
         args.only_lint_under_config_dir
     };


### PR DESCRIPTION
On my setup lintrunner was failing like this:
```
(py39) $ lintrunner --take RUFF --all-files
error:        No such file or directory (os error 2)
```
The underlying error was because there's a file with non-ascii characters in the name.

There are two problems:
1. When a file reported by `git` wasn't found it was reporting the error without any context about the filename.
2. The files being returned by `git` are escaped by `git` and then passed through a utf-8 `String`.

This PR adds context for the names so when an error does occur the user can at least tell what file had the problem.

Additionally it changes how `--all-files` gets its filenames so it doesn't pass them through String (which incorrectly does utf-8 encoding on them).

There are some additional incorrect handling of paths in other areas of the code (`get_paths_from_cmd` for example) which should probably be fixed in a similar manner in the future (or maybe merged with the all-files handling).
