### PR TITLE
Feature/allow rv64 package

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: linux-wheels
+          name: linux-wheels-${{ matrix.target }}
           path: dist
 
   windows:
@@ -95,7 +95,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: windows-wheels
+          name: windows-wheels-${{ matrix.target }}
           path: dist
 
   macos:
@@ -115,7 +115,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: macos-wheels
+          name: macos-wheels-${{ matrix.target }}
           path: dist
 
   sdist:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,10 +7,10 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+    # branches:
+    #   - main
+    # tags:
+    #   - 'v*'
   pull_request:
   workflow_dispatch:
 
@@ -62,7 +62,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        target: [x86_64, aarch64]
+        target: [x86_64, aarch64, riscv64gc-unknown-linux-gnu]
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: linux-wheels
           path: dist
 
   windows:
@@ -95,7 +95,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: windows-wheels
           path: dist
 
   macos:
@@ -115,7 +115,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: macos-wheels
           path: dist
 
   sdist:
@@ -131,7 +131,7 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: sdist
           path: dist
 
   release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin==1.9.3"]
 build-backend = "maturin"
 
 [project]
 name = "lintrunner"
+version = "0.12.7"
 requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
PyPI recently added support for hosting whl packages for riscv64, so we can consider adding support for riscv64 packaging.

Here are the CI results,[link](https://github.com/ffgan/lintrunner/actions/runs/16987058376), which show that the riscv64 whl can be built successfully.

A few points to note:

1. To facilitate testing, I modified the CI trigger conditions. If they're not working, please let me know and I'll add a commit to restore the original trigger conditions.

2. Recently, CI seems to have issues with uploading artifacts. I've modified them to allow CI to pass successfully, but release builds haven't been tested yet. If you encounter any issues with the release build, please feel free to contact me. I'd be happy to help resolve the CI issue.



Other Information
Co-authored by: [nijincheng@iscas.ac.cn](mailto:nijincheng@iscas.ac.cn);